### PR TITLE
Test setting MLLP default charset from system property for native mode

### DIFF
--- a/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
+++ b/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
@@ -17,7 +17,6 @@
 package org.apache.camel.quarkus.component.mllp.it;
 
 import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
@@ -58,7 +57,6 @@ class MllpTest {
     }
 
     @Test
-    @DisabledOnNativeImage("https://github.com/apache/camel-quarkus/issues/2554")
     public void testCharsetFromMsh18() {
         // Set up the message with a charset and some characters that it cannot deal with
         String messageWithCharset = HL7_MESSAGE.replace("NE||", "NE||ISO-8859-1").replace("INHOUSE", "ÏNHOUSE");
@@ -82,7 +80,6 @@ class MllpTest {
     }
 
     @Test
-    @DisabledOnNativeImage("https://github.com/apache/camel-quarkus/issues/2554")
     public void testDefaultCharsetFromSystemProperty() {
         RestAssured.get("/mllp/charset/default")
                 .then()


### PR DESCRIPTION
Fixes #2554