### PR TITLE
Fix failures in native tests for supported components

### DIFF
--- a/integration-tests/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectIT.java
+++ b/integration-tests/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectIT.java
@@ -20,4 +20,9 @@ import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
 public class DirectIT extends DirectTest {
+
+    DirectIT() {
+        logPath = "target/target/quarkus.log";
+    }
+
 }

--- a/integration-tests/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectTest.java
+++ b/integration-tests/direct/src/test/java/org/apache/camel/quarkus/component/direct/it/DirectTest.java
@@ -34,6 +34,9 @@ import static org.hamcrest.core.IsNot.not;
 
 @QuarkusTest
 public class DirectTest {
+
+    protected String logPath = "target/quarkus.log";
+
     @Test
     public void catalogComponent() throws IOException {
         RestAssured.when().get("/direct/catalog/component/direct").then().body(not(emptyOrNullString()));
@@ -61,7 +64,7 @@ public class DirectTest {
                 .statusCode(204);
 
         await().atMost(10L, TimeUnit.SECONDS).pollDelay(100, TimeUnit.MILLISECONDS).until(() -> {
-            String log = new String(Files.readAllBytes(Paths.get("target/quarkus.log")), StandardCharsets.UTF_8);
+            String log = new String(Files.readAllBytes(Paths.get(logPath)), StandardCharsets.UTF_8);
             return log.contains(message1) && log.contains(message2);
         });
     }

--- a/integration-tests/log/pom.xml
+++ b/integration-tests/log/pom.xml
@@ -34,6 +34,11 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-log</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
+
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/main-unknown-args-fail/src/main/java/org/apache/camel/quarkus/main/unknown/args/fail/Routes.java
+++ b/integration-tests/main-unknown-args-fail/src/main/java/org/apache/camel/quarkus/main/unknown/args/fail/Routes.java
@@ -22,7 +22,7 @@ public class Routes extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("timer:tick?repeatCount=1&delay=-1")
+        from("timer:tick?repeatCount=10&delay=60")
                 .log("Timer tick!");
     }
 }

--- a/integration-tests/main-unknown-args-fail/src/main/resources/application.properties
+++ b/integration-tests/main-unknown-args-fail/src/main/resources/application.properties
@@ -16,6 +16,6 @@
 ## ---------------------------------------------------------------------------
 
 # Terminate after 1 message is generated
-camel.main.duration-max-messages = 1
+camel.main.duration-max-messages = 10
 
 quarkus.camel.main.arguments.on-unknown = fail

--- a/integration-tests/main-unknown-args-ignore/src/main/java/org/apache/camel/quarkus/main/unknown/args/ignore/Routes.java
+++ b/integration-tests/main-unknown-args-ignore/src/main/java/org/apache/camel/quarkus/main/unknown/args/ignore/Routes.java
@@ -22,7 +22,7 @@ public class Routes extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("timer:tick?repeatCount=1&delay=-1")
+        from("timer:tick?repeatCount=10&delay=60")
                 .log("Timer tick!");
     }
 }

--- a/integration-tests/main-unknown-args-ignore/src/main/resources/application.properties
+++ b/integration-tests/main-unknown-args-ignore/src/main/resources/application.properties
@@ -16,6 +16,6 @@
 ## ---------------------------------------------------------------------------
 
 # Terminate after 1 message is generated
-camel.main.duration-max-messages = 1
+camel.main.duration-max-messages = 10
 
 quarkus.camel.main.arguments.on-unknown = ignore

--- a/integration-tests/timer/pom.xml
+++ b/integration-tests/timer/pom.xml
@@ -34,6 +34,10 @@
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-timer</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/integration-tests/timer/src/main/java/org/apache/camel/quarkus/component/timer/it/TimerProducers.java
+++ b/integration-tests/timer/src/main/java/org/apache/camel/quarkus/component/timer/it/TimerProducers.java
@@ -31,5 +31,4 @@ public class TimerProducers {
         return rb -> rb.from("timer:bar").routeId("bar")
                 .process(e -> LOG.info("Hello from timer:bar"));
     }
-
 }


### PR DESCRIPTION
The Quarkus native image runner needs the application to run for a little while which caused failures in Main.
timer and log weren't exposing socket which is one requirement of Quarkus to see the app as running.
And native logs are in "target/target/quarkus.log" which caused direct tests to look at the JVM logs, causing failures.