### PR TITLE
Add tooling - need it to build camel-quarkus-maven-plugin

### DIFF
--- a/.mvn/excludes.txt
+++ b/.mvn/excludes.txt
@@ -1066,7 +1066,6 @@
 :camel-quarkus-tika
 :camel-quarkus-tika-deployment
 :camel-quarkus-tika-parent
-:camel-quarkus-tooling
 :camel-quarkus-twilio
 :camel-quarkus-twilio-deployment
 :camel-quarkus-twilio-parent


### PR DESCRIPTION
Need to add the camel-quarkus-tooling module so that we build camel-quarkus-maven-plugin
https://orch.psi.redhat.com/pnc-web/#/projects/788/build-configs/5958/builds/AMFHNDWQV4AAA/build-log