### PR TITLE
Add exclusion of io.netty:netty-resolver-dns-native-macos

### DIFF
--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5162,6 +5162,12 @@
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-reactor-netty</artifactId>
                 <version>${camel-quarkus-community.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>


### PR DESCRIPTION
I think we need to add this exclusion to the bom - we're pulling in version 2.1.0 of the camel-quarkus-support-reactor-netty extension, which does not have this exclusion.