### PR TITLE
Remove integration tests temporarily for kafka-sasl

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -128,8 +128,6 @@
         <module>jsonpath</module>
         <module>jta</module>
         <module>kafka</module>
-        <module>kafka-sasl</module>
-        <module>kafka-sasl-ssl</module>
         <module>kafka-ssl</module>
         <module>kamelet</module>
         <module>kotlin</module>


### PR DESCRIPTION
Need to temporarily remove the kafka-sasl integration tests.    We need to run versions:set without the exclusion plugin active in order to set the versions completely correctly.     These modules are already excluded in excludes.txt, but they need to be excluded during the versions:set also.

https://ci-jenkins-csb-fuse.apps.ocp4.prod.psi.redhat.com/job/integration.next/job/next-camel-quarkus-build-8.5/35/console

