### PR TITLE
Use camel-quarkus-build-parent-it as a direct parent of each test module

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -44,6 +44,9 @@ pipeline {
                 sh "docker container prune -f"
                 configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                     sh "./mvnw ${MAVEN_PARAMS} clean install -Dquickly"
+                    sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar cfz cq-artifacts.tgz *"
+                    sh "mv -t . /home/jenkins/.m2/repository/org/apache/camel/quarkus/cq-artifacts.tgz"
+                    stash name: 'cq-artifacts', includes: 'cq-artifacts.tgz'
                 }
             }
         }
@@ -56,6 +59,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-product/group-01 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -72,6 +78,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-product/group-02 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -88,6 +97,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-allowed/group-01 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -104,6 +116,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-jvm/group-01 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -120,6 +135,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-01 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -136,6 +154,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-02 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -152,6 +173,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-03 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -168,6 +192,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-04 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -184,6 +211,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-05 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }
@@ -200,6 +230,9 @@ pipeline {
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd product/integration-tests-mixed-native/group-06 && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -160,6 +160,32 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-azure-storage-blob</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-azure-storage-queue</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-bean</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
@@ -174,6 +200,19 @@
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-bindy</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-cassandraql</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
@@ -667,7 +706,33 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-telegram</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-timer</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-xml-io-dsl</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>

--- a/extensions-core/pom.xml
+++ b/extensions-core/pom.xml
@@ -37,7 +37,7 @@
         <module>http-common</module>
         <!-- <module>reactive-executor</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>threadpoolfactory-vertx</module> disabled by cq-prod-maven-plugin:prod-excludes -->
-        <!-- <module>xml-io-dsl</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>xml-io-dsl</module>
         <!-- <module>xml-jaxb</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>xml-jaxp</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>caffeine-lrucache</module> disabled by cq-prod-maven-plugin:prod-excludes -->

--- a/extensions-support/pom.xml
+++ b/extensions-support/pom.xml
@@ -33,10 +33,10 @@
 
     <modules>
         <!-- extensions a..z; do not remove this comment, it is important when sorting via  mvn process-resources -Pformat -->
-        <!-- <module>ahc</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>ahc</module>
         <!-- <module>aws</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>aws2</module>
-        <!-- <module>azure-core</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>azure-core</module>
         <!-- <module>bouncycastle</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>common</module>
         <module>commons-logging</module>
@@ -48,7 +48,7 @@
         <module>jetty</module>
         <!-- <module>mail</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>mongodb</module>
-        <!-- <module>reactor-netty</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>reactor-netty</module>
         <!-- <module>retrofit</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>spring</module>
         <!-- <module>stax</module> disabled by cq-prod-maven-plugin:prod-excludes -->

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -64,8 +64,8 @@
         <!-- <module>aws2-sts</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>aws2-translate</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>azure-eventhubs</module> disabled by cq-prod-maven-plugin:prod-excludes -->
-        <!-- <module>azure-storage-blob</module> disabled by cq-prod-maven-plugin:prod-excludes -->
-        <!-- <module>azure-storage-queue</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>azure-storage-blob</module>
+        <module>azure-storage-queue</module>
         <!-- <module>base64</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>bean</module>
         <!-- <module>bean-validator</module> disabled by cq-prod-maven-plugin:prod-excludes -->
@@ -74,7 +74,7 @@
         <!-- <module>braintree</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>browse</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>caffeine</module> disabled by cq-prod-maven-plugin:prod-excludes -->
-        <!-- <module>cassandraql</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>cassandraql</module>
         <!-- <module>cbor</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>consul</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>controlbus</module> disabled by cq-prod-maven-plugin:prod-excludes -->
@@ -224,7 +224,7 @@
         <!-- <module>syslog</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>tagsoup</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>tarfile</module> disabled by cq-prod-maven-plugin:prod-excludes -->
-        <!-- <module>telegram</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>telegram</module>
         <!-- <module>tika</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>timer</module>
         <!-- <module>twilio</module> disabled by cq-prod-maven-plugin:prod-excludes -->

--- a/integration-test-groups/aws2/aws2-cw/pom.xml
+++ b/integration-test-groups/aws2/aws2-cw/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-cw</artifactId>

--- a/integration-test-groups/aws2/aws2-ddb/pom.xml
+++ b/integration-test-groups/aws2/aws2-ddb/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-ddb</artifactId>

--- a/integration-test-groups/aws2/aws2-kinesis/pom.xml
+++ b/integration-test-groups/aws2/aws2-kinesis/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-kinesis</artifactId>

--- a/integration-test-groups/aws2/aws2-lambda/pom.xml
+++ b/integration-test-groups/aws2/aws2-lambda/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-lambda</artifactId>

--- a/integration-test-groups/aws2/aws2-s3/pom.xml
+++ b/integration-test-groups/aws2/aws2-s3/pom.xml
@@ -18,12 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-aws2-s3</artifactId>
     <name>Camel Quarkus :: Integration Tests :: AWS2 S3</name>

--- a/integration-test-groups/aws2/aws2-ses/pom.xml
+++ b/integration-test-groups/aws2/aws2-ses/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-ses</artifactId>

--- a/integration-test-groups/aws2/aws2-sqs-sns/pom.xml
+++ b/integration-test-groups/aws2/aws2-sqs-sns/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-aws2</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-aws2-sqs-sns</artifactId>

--- a/integration-test-groups/azure/azure-eventhubs/pom.xml
+++ b/integration-test-groups/azure/azure-eventhubs/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-azure</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-azure-eventhubs</artifactId>

--- a/integration-test-groups/azure/azure-storage-blob/pom.xml
+++ b/integration-test-groups/azure/azure-storage-blob/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-azure</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-azure-storage-blob</artifactId>

--- a/integration-test-groups/azure/azure-storage-queue/pom.xml
+++ b/integration-test-groups/azure/azure-storage-queue/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-azure</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-azure-storage-queue</artifactId>

--- a/integration-test-groups/foundation/bean/pom.xml
+++ b/integration-test-groups/foundation/bean/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-bean</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Bean</name>

--- a/integration-test-groups/foundation/browse/pom.xml
+++ b/integration-test-groups/foundation/browse/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-browse</artifactId>

--- a/integration-test-groups/foundation/component-name-resolver/pom.xml
+++ b/integration-test-groups/foundation/component-name-resolver/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-component-name-resolver</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Component Name Resolver :: Tests</name>

--- a/integration-test-groups/foundation/controlbus/pom.xml
+++ b/integration-test-groups/foundation/controlbus/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-controlbus</artifactId>

--- a/integration-test-groups/foundation/core-annotations/pom.xml
+++ b/integration-test-groups/foundation/core-annotations/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-core-annotations</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core Annotations :: Tests</name>

--- a/integration-test-groups/foundation/core-fault-tolerance/pom.xml
+++ b/integration-test-groups/foundation/core-fault-tolerance/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-core-faulttolerance</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core Fault Tolerance :: Tests</name>

--- a/integration-test-groups/foundation/core-languages/pom.xml
+++ b/integration-test-groups/foundation/core-languages/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-core-languages</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core Languages :: Tests</name>

--- a/integration-test-groups/foundation/core-thread-pools/pom.xml
+++ b/integration-test-groups/foundation/core-thread-pools/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-core-threadpools</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core Thread Pools :: Tests</name>

--- a/integration-test-groups/foundation/core/pom.xml
+++ b/integration-test-groups/foundation/core/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-core</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Core :: Tests</name>

--- a/integration-test-groups/foundation/customized-log-component/pom.xml
+++ b/integration-test-groups/foundation/customized-log-component/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-customized-log-component</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Customize Log component :: Tests</name>

--- a/integration-test-groups/foundation/direct/pom.xml
+++ b/integration-test-groups/foundation/direct/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
         <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-direct</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Direct :: Tests</name>

--- a/integration-test-groups/foundation/eip/pom.xml
+++ b/integration-test-groups/foundation/eip/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-eip</artifactId>

--- a/integration-test-groups/foundation/language/pom.xml
+++ b/integration-test-groups/foundation/language/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-language</artifactId>

--- a/integration-test-groups/foundation/log/pom.xml
+++ b/integration-test-groups/foundation/log/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-log</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Log :: Tests</name>

--- a/integration-test-groups/foundation/mock/pom.xml
+++ b/integration-test-groups/foundation/mock/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-mock</artifactId>

--- a/integration-test-groups/foundation/ref/pom.xml
+++ b/integration-test-groups/foundation/ref/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-ref</artifactId>

--- a/integration-test-groups/foundation/scheduler/pom.xml
+++ b/integration-test-groups/foundation/scheduler/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-scheduler</artifactId>

--- a/integration-test-groups/foundation/seda/pom.xml
+++ b/integration-test-groups/foundation/seda/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-seda</artifactId>

--- a/integration-test-groups/foundation/stream/pom.xml
+++ b/integration-test-groups/foundation/stream/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-stream</artifactId>

--- a/integration-test-groups/foundation/timer/pom.xml
+++ b/integration-test-groups/foundation/timer/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-timer</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Timer :: Tests</name>

--- a/integration-test-groups/foundation/type-converter/pom.xml
+++ b/integration-test-groups/foundation/type-converter/pom.xml
@@ -18,13 +18,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-foundation</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>camel-quarkus-integration-test-type-converter</artifactId>
     <name>Camel Quarkus :: Integration Tests :: Type Converter :: Tests</name>

--- a/integration-test-groups/mongodb/mongodb-gridfs/pom.xml
+++ b/integration-test-groups/mongodb/mongodb-gridfs/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-mongodb</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-mongodb-gridfs</artifactId>

--- a/integration-test-groups/mongodb/mongodb/pom.xml
+++ b/integration-test-groups/mongodb/mongodb/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests-mongodb</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-mongodb</artifactId>

--- a/integration-test-groups/pom.xml
+++ b/integration-test-groups/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-groups</artifactId>

--- a/integration-tests-support/pom.xml
+++ b/integration-tests-support/pom.xml
@@ -38,7 +38,7 @@
     <modules>
         <!-- <module>activemq</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>aws2</module>
-        <!-- <module>azure</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>azure</module>
         <!-- <module>custom-dataformat</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>custom-log-component</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>custom-routes-collector</module> disabled by cq-prod-maven-plugin:prod-excludes -->

--- a/integration-tests/activemq/pom.xml
+++ b/integration-tests/activemq/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-activemq</artifactId>

--- a/integration-tests/amqp/pom.xml
+++ b/integration-tests/amqp/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-amqp</artifactId>

--- a/integration-tests/arangodb/pom.xml
+++ b/integration-tests/arangodb/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-arangodb</artifactId>

--- a/integration-tests/as2/pom.xml
+++ b/integration-tests/as2/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-as2</artifactId>

--- a/integration-tests/atlasmap/pom.xml
+++ b/integration-tests/atlasmap/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-atlasmap</artifactId>

--- a/integration-tests/avro-rpc/pom.xml
+++ b/integration-tests/avro-rpc/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-avro-rpc</artifactId>

--- a/integration-tests/avro/pom.xml
+++ b/integration-tests/avro/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-avro</artifactId>

--- a/integration-tests/aws2-grouped/pom.xml
+++ b/integration-tests/aws2-grouped/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/aws2/pom.xml
+++ b/integration-tests/aws2/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/azure-grouped/pom.xml
+++ b/integration-tests/azure-grouped/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/base64/pom.xml
+++ b/integration-tests/base64/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-base64</artifactId>

--- a/integration-tests/bean-validator/pom.xml
+++ b/integration-tests/bean-validator/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-bean-validator</artifactId>

--- a/integration-tests/bindy/pom.xml
+++ b/integration-tests/bindy/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-bindy</artifactId>

--- a/integration-tests/box/pom.xml
+++ b/integration-tests/box/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-box</artifactId>

--- a/integration-tests/braintree/pom.xml
+++ b/integration-tests/braintree/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-braintree</artifactId>

--- a/integration-tests/caffeine/pom.xml
+++ b/integration-tests/caffeine/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-caffeine</artifactId>

--- a/integration-tests/cassandraql/pom.xml
+++ b/integration-tests/cassandraql/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-cassandraql</artifactId>

--- a/integration-tests/cbor/pom.xml
+++ b/integration-tests/cbor/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-cbor</artifactId>

--- a/integration-tests/compression/pom.xml
+++ b/integration-tests/compression/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-compression</artifactId>

--- a/integration-tests/consul/pom.xml
+++ b/integration-tests/consul/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-consul</artifactId>

--- a/integration-tests/core-discovery-disabled/pom.xml
+++ b/integration-tests/core-discovery-disabled/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/couchdb/pom.xml
+++ b/integration-tests/couchdb/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-couchdb</artifactId>

--- a/integration-tests/crypto/pom.xml
+++ b/integration-tests/crypto/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-crypto</artifactId>

--- a/integration-tests/csimple/pom.xml
+++ b/integration-tests/csimple/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-csimple</artifactId>

--- a/integration-tests/csv/pom.xml
+++ b/integration-tests/csv/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-csv</artifactId>

--- a/integration-tests/dataformat/pom.xml
+++ b/integration-tests/dataformat/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-dataformat</artifactId>

--- a/integration-tests/dataformats-json/pom.xml
+++ b/integration-tests/dataformats-json/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/debezium/pom.xml
+++ b/integration-tests/debezium/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-debezium</artifactId>

--- a/integration-tests/digitalocean/pom.xml
+++ b/integration-tests/digitalocean/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-digitalocean</artifactId>

--- a/integration-tests/disruptor/pom.xml
+++ b/integration-tests/disruptor/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-disruptor</artifactId>

--- a/integration-tests/dozer/pom.xml
+++ b/integration-tests/dozer/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-dozer</artifactId>

--- a/integration-tests/dropbox/pom.xml
+++ b/integration-tests/dropbox/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-dropbox</artifactId>

--- a/integration-tests/elasticsearch-rest/pom.xml
+++ b/integration-tests/elasticsearch-rest/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-elasticsearch-rest</artifactId>

--- a/integration-tests/exec/pom.xml
+++ b/integration-tests/exec/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-exec</artifactId>

--- a/integration-tests/fhir/pom.xml
+++ b/integration-tests/fhir/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-fhir</artifactId>

--- a/integration-tests/file/pom.xml
+++ b/integration-tests/file/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-file</artifactId>

--- a/integration-tests/flatpack/pom.xml
+++ b/integration-tests/flatpack/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-flatpack</artifactId>

--- a/integration-tests/fop/pom.xml
+++ b/integration-tests/fop/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-fop</artifactId>

--- a/integration-tests/foundation-grouped/pom.xml
+++ b/integration-tests/foundation-grouped/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/freemarker/pom.xml
+++ b/integration-tests/freemarker/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-freemarker</artifactId>

--- a/integration-tests/ftp/pom.xml
+++ b/integration-tests/ftp/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-ftp</artifactId>

--- a/integration-tests/geocoder/pom.xml
+++ b/integration-tests/geocoder/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-geocoder</artifactId>

--- a/integration-tests/git/pom.xml
+++ b/integration-tests/git/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-git</artifactId>

--- a/integration-tests/github/pom.xml
+++ b/integration-tests/github/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-github</artifactId>

--- a/integration-tests/google-bigquery/pom.xml
+++ b/integration-tests/google-bigquery/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-google-bigquery</artifactId>

--- a/integration-tests/google-pubsub/pom.xml
+++ b/integration-tests/google-pubsub/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-google-pubsub</artifactId>

--- a/integration-tests/google-storage/pom.xml
+++ b/integration-tests/google-storage/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-google-storage</artifactId>

--- a/integration-tests/google/pom.xml
+++ b/integration-tests/google/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-google</artifactId>

--- a/integration-tests/graphql/pom.xml
+++ b/integration-tests/graphql/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-graphql</artifactId>

--- a/integration-tests/grok/pom.xml
+++ b/integration-tests/grok/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-grok</artifactId>

--- a/integration-tests/grpc/pom.xml
+++ b/integration-tests/grpc/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-grpc</artifactId>

--- a/integration-tests/hazelcast/pom.xml
+++ b/integration-tests/hazelcast/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-hazelcast</artifactId>

--- a/integration-tests/headersmap/pom.xml
+++ b/integration-tests/headersmap/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-headersmap</artifactId>

--- a/integration-tests/hl7/pom.xml
+++ b/integration-tests/hl7/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-hl7</artifactId>

--- a/integration-tests/http/pom.xml
+++ b/integration-tests/http/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-http</artifactId>

--- a/integration-tests/hystrix/pom.xml
+++ b/integration-tests/hystrix/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-hystrix</artifactId>

--- a/integration-tests/infinispan/pom.xml
+++ b/integration-tests/infinispan/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/influxdb/pom.xml
+++ b/integration-tests/influxdb/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-influxdb</artifactId>

--- a/integration-tests/ipfs/pom.xml
+++ b/integration-tests/ipfs/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-ipfs</artifactId>

--- a/integration-tests/jackson-avro/pom.xml
+++ b/integration-tests/jackson-avro/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jackson-avro</artifactId>

--- a/integration-tests/jackson-protobuf/pom.xml
+++ b/integration-tests/jackson-protobuf/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jackson-protobuf</artifactId>

--- a/integration-tests/jaxb/pom.xml
+++ b/integration-tests/jaxb/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jaxb</artifactId>

--- a/integration-tests/jdbc/pom.xml
+++ b/integration-tests/jdbc/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jing/pom.xml
+++ b/integration-tests/jing/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jing</artifactId>

--- a/integration-tests/jira/pom.xml
+++ b/integration-tests/jira/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jira</artifactId>

--- a/integration-tests/jms-artemis-client/pom.xml
+++ b/integration-tests/jms-artemis-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jms-artemis-client</artifactId>

--- a/integration-tests/jms-qpid-amqp-client/pom.xml
+++ b/integration-tests/jms-qpid-amqp-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jms-qpid-amqp-client</artifactId>

--- a/integration-tests/jolt/pom.xml
+++ b/integration-tests/jolt/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jolt</artifactId>

--- a/integration-tests/jpa/pom.xml
+++ b/integration-tests/jpa/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jpa</artifactId>

--- a/integration-tests/js-dsl/pom.xml
+++ b/integration-tests/js-dsl/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jsch/pom.xml
+++ b/integration-tests/jsch/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jsch</artifactId>

--- a/integration-tests/jslt/pom.xml
+++ b/integration-tests/jslt/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jslt</artifactId>

--- a/integration-tests/json-validator/pom.xml
+++ b/integration-tests/json-validator/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-json-validator</artifactId>

--- a/integration-tests/jsonata/pom.xml
+++ b/integration-tests/jsonata/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jsonata</artifactId>

--- a/integration-tests/jsonpath/pom.xml
+++ b/integration-tests/jsonpath/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jsonpath</artifactId>

--- a/integration-tests/jta/pom.xml
+++ b/integration-tests/jta/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-jta</artifactId>

--- a/integration-tests/kafka-sasl-ssl/pom.xml
+++ b/integration-tests/kafka-sasl-ssl/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kafka-sasl-ssl</artifactId>

--- a/integration-tests/kafka-sasl/pom.xml
+++ b/integration-tests/kafka-sasl/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kafka-sasl</artifactId>

--- a/integration-tests/kafka-ssl/pom.xml
+++ b/integration-tests/kafka-ssl/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kafka-ssl</artifactId>

--- a/integration-tests/kafka/pom.xml
+++ b/integration-tests/kafka/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kafka</artifactId>

--- a/integration-tests/kamelet/pom.xml
+++ b/integration-tests/kamelet/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kamelet</artifactId>

--- a/integration-tests/kotlin/pom.xml
+++ b/integration-tests/kotlin/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/kubernetes/pom.xml
+++ b/integration-tests/kubernetes/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kubernetes</artifactId>

--- a/integration-tests/kudu/pom.xml
+++ b/integration-tests/kudu/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-kudu</artifactId>

--- a/integration-tests/leveldb/pom.xml
+++ b/integration-tests/leveldb/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-leveldb</artifactId>

--- a/integration-tests/lra/pom.xml
+++ b/integration-tests/lra/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-lra</artifactId>

--- a/integration-tests/lumberjack/pom.xml
+++ b/integration-tests/lumberjack/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-lumberjack</artifactId>

--- a/integration-tests/mail/pom.xml
+++ b/integration-tests/mail/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-caffeine-lrucache/pom.xml
+++ b/integration-tests/main-caffeine-lrucache/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-collector/pom.xml
+++ b/integration-tests/main-collector/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-command-mode/pom.xml
+++ b/integration-tests/main-command-mode/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-devmode/pom.xml
+++ b/integration-tests/main-devmode/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-discovery-disabled/pom.xml
+++ b/integration-tests/main-discovery-disabled/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-unknown-args-fail/pom.xml
+++ b/integration-tests/main-unknown-args-fail/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-unknown-args-ignore/pom.xml
+++ b/integration-tests/main-unknown-args-ignore/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-xml-io/pom.xml
+++ b/integration-tests/main-xml-io/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-xml-jaxb/pom.xml
+++ b/integration-tests/main-xml-jaxb/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main-yaml/pom.xml
+++ b/integration-tests/main-yaml/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/master/pom.xml
+++ b/integration-tests/master/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-master</artifactId>

--- a/integration-tests/messaging/pom.xml
+++ b/integration-tests/messaging/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-messaging</artifactId>

--- a/integration-tests/micrometer/pom.xml
+++ b/integration-tests/micrometer/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-micrometer</artifactId>

--- a/integration-tests/microprofile/pom.xml
+++ b/integration-tests/microprofile/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-microprofile</artifactId>

--- a/integration-tests/minio/pom.xml
+++ b/integration-tests/minio/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-minio</artifactId>

--- a/integration-tests/mllp/pom.xml
+++ b/integration-tests/mllp/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-mllp</artifactId>

--- a/integration-tests/mongodb-grouped/pom.xml
+++ b/integration-tests/mongodb-grouped/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/msv/pom.xml
+++ b/integration-tests/msv/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-msv</artifactId>

--- a/integration-tests/mustache/pom.xml
+++ b/integration-tests/mustache/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-mustache</artifactId>

--- a/integration-tests/nagios/pom.xml
+++ b/integration-tests/nagios/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-nagios</artifactId>

--- a/integration-tests/nats/pom.xml
+++ b/integration-tests/nats/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-nats</artifactId>

--- a/integration-tests/netty/pom.xml
+++ b/integration-tests/netty/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-netty</artifactId>

--- a/integration-tests/nitrite/pom.xml
+++ b/integration-tests/nitrite/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-nitrite</artifactId>

--- a/integration-tests/nsq/pom.xml
+++ b/integration-tests/nsq/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-nsq</artifactId>

--- a/integration-tests/oaipmh/pom.xml
+++ b/integration-tests/oaipmh/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-oaipmh</artifactId>

--- a/integration-tests/olingo4/pom.xml
+++ b/integration-tests/olingo4/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-olingo4</artifactId>

--- a/integration-tests/openapi-java/pom.xml
+++ b/integration-tests/openapi-java/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-openapi-java</artifactId>

--- a/integration-tests/openstack/pom.xml
+++ b/integration-tests/openstack/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-openstack</artifactId>

--- a/integration-tests/opentelemetry/pom.xml
+++ b/integration-tests/opentelemetry/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-opentelemetry</artifactId>

--- a/integration-tests/opentracing/pom.xml
+++ b/integration-tests/opentracing/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-opentracing</artifactId>

--- a/integration-tests/optaplanner/pom.xml
+++ b/integration-tests/optaplanner/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-optaplanner</artifactId>

--- a/integration-tests/paho-mqtt5/pom.xml
+++ b/integration-tests/paho-mqtt5/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-paho-mqtt5</artifactId>

--- a/integration-tests/paho/pom.xml
+++ b/integration-tests/paho/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-paho</artifactId>

--- a/integration-tests/pdf/pom.xml
+++ b/integration-tests/pdf/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <artifactId>camel-quarkus-integration-test-pdf</artifactId>
     <name>Camel Quarkus :: Integration Tests :: PDF</name>

--- a/integration-tests/pg-replication-slot/pom.xml
+++ b/integration-tests/pg-replication-slot/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-pg-replication-slot</artifactId>

--- a/integration-tests/pgevent/pom.xml
+++ b/integration-tests/pgevent/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-pgevent</artifactId>

--- a/integration-tests/platform-http-engine/pom.xml
+++ b/integration-tests/platform-http-engine/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-platform-http-engine</artifactId>

--- a/integration-tests/platform-http/pom.xml
+++ b/integration-tests/platform-http/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-platform-http</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-tests</artifactId>

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-protobuf</artifactId>

--- a/integration-tests/pubnub/pom.xml
+++ b/integration-tests/pubnub/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-pubnub</artifactId>

--- a/integration-tests/quartz/pom.xml
+++ b/integration-tests/quartz/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-quartz</artifactId>

--- a/integration-tests/qute/pom.xml
+++ b/integration-tests/qute/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-qute</artifactId>

--- a/integration-tests/rabbitmq/pom.xml
+++ b/integration-tests/rabbitmq/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-rabbitmq</artifactId>

--- a/integration-tests/reactive-streams/pom.xml
+++ b/integration-tests/reactive-streams/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-reactive-streams</artifactId>

--- a/integration-tests/rest-openapi/pom.xml
+++ b/integration-tests/rest-openapi/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-rest-openapi</artifactId>

--- a/integration-tests/rest/pom.xml
+++ b/integration-tests/rest/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-rest</artifactId>

--- a/integration-tests/saga/pom.xml
+++ b/integration-tests/saga/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-saga</artifactId>

--- a/integration-tests/salesforce/pom.xml
+++ b/integration-tests/salesforce/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/sap-netweaver/pom.xml
+++ b/integration-tests/sap-netweaver/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sap-netweaver</artifactId>

--- a/integration-tests/saxon/pom.xml
+++ b/integration-tests/saxon/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-saxon</artifactId>

--- a/integration-tests/servicenow/pom.xml
+++ b/integration-tests/servicenow/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-servicenow</artifactId>

--- a/integration-tests/servlet/pom.xml
+++ b/integration-tests/servlet/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-servlet</artifactId>

--- a/integration-tests/shiro/pom.xml
+++ b/integration-tests/shiro/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-shiro</artifactId>

--- a/integration-tests/sjms-artemis-client/pom.xml
+++ b/integration-tests/sjms-artemis-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sjms-artemis-client</artifactId>

--- a/integration-tests/sjms-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms-qpid-amqp-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sjms-qpid-amqp-client</artifactId>

--- a/integration-tests/sjms2-artemis-client/pom.xml
+++ b/integration-tests/sjms2-artemis-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sjms2-artemis-client</artifactId>

--- a/integration-tests/sjms2-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms2-qpid-amqp-client/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sjms2-qpid-amqp-client</artifactId>

--- a/integration-tests/slack/pom.xml
+++ b/integration-tests/slack/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-slack</artifactId>

--- a/integration-tests/smallrye-reactive-messaging/pom.xml
+++ b/integration-tests/smallrye-reactive-messaging/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-smallrye-reactive-messaging</artifactId>

--- a/integration-tests/soap/pom.xml
+++ b/integration-tests/soap/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-soap</artifactId>

--- a/integration-tests/solr/pom.xml
+++ b/integration-tests/solr/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-solr</artifactId>

--- a/integration-tests/splunk/pom.xml
+++ b/integration-tests/splunk/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-splunk</artifactId>

--- a/integration-tests/spring-rabbitmq/pom.xml
+++ b/integration-tests/spring-rabbitmq/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-spring-rabbitmq</artifactId>

--- a/integration-tests/sql/pom.xml
+++ b/integration-tests/sql/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-sql</artifactId>

--- a/integration-tests/ssh/pom.xml
+++ b/integration-tests/ssh/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-ssh-integration-test</artifactId>

--- a/integration-tests/stax/pom.xml
+++ b/integration-tests/stax/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-stax</artifactId>

--- a/integration-tests/stringtemplate/pom.xml
+++ b/integration-tests/stringtemplate/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-stringtemplate</artifactId>

--- a/integration-tests/syndication/pom.xml
+++ b/integration-tests/syndication/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-syndication</artifactId>

--- a/integration-tests/syslog/pom.xml
+++ b/integration-tests/syslog/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-syslog</artifactId>

--- a/integration-tests/tarfile/pom.xml
+++ b/integration-tests/tarfile/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-tarfile</artifactId>

--- a/integration-tests/telegram/pom.xml
+++ b/integration-tests/telegram/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-telegram</artifactId>

--- a/integration-tests/tika/pom.xml
+++ b/integration-tests/tika/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>        
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-tika</artifactId>

--- a/integration-tests/twilio/pom.xml
+++ b/integration-tests/twilio/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-twilio</artifactId>

--- a/integration-tests/twitter/pom.xml
+++ b/integration-tests/twitter/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/univocity-parsers/pom.xml
+++ b/integration-tests/univocity-parsers/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-univocity-parsers</artifactId>

--- a/integration-tests/validator/pom.xml
+++ b/integration-tests/validator/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-validator</artifactId>

--- a/integration-tests/velocity/pom.xml
+++ b/integration-tests/velocity/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-velocity</artifactId>

--- a/integration-tests/vertx-kafka/pom.xml
+++ b/integration-tests/vertx-kafka/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-vertx-kafka</artifactId>

--- a/integration-tests/vertx-websocket/pom.xml
+++ b/integration-tests/vertx-websocket/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-vertx-websocket</artifactId>

--- a/integration-tests/vertx/pom.xml
+++ b/integration-tests/vertx/pom.xml
@@ -21,9 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-vertx</artifactId>

--- a/integration-tests/weather/pom.xml
+++ b/integration-tests/weather/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-weather</artifactId>

--- a/integration-tests/xchange/pom.xml
+++ b/integration-tests/xchange/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-xchange</artifactId>

--- a/integration-tests/xml/pom.xml
+++ b/integration-tests/xml/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-xml</artifactId>

--- a/integration-tests/xmlsecurity/pom.xml
+++ b/integration-tests/xmlsecurity/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-xmlsecurity</artifactId>

--- a/integration-tests/xpath/pom.xml
+++ b/integration-tests/xpath/pom.xml
@@ -20,8 +20,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/xstream/pom.xml
+++ b/integration-tests/xstream/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-xstream</artifactId>

--- a/integration-tests/zendesk/pom.xml
+++ b/integration-tests/zendesk/pom.xml
@@ -21,8 +21,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-integration-tests</artifactId>
+        <artifactId>camel-quarkus-build-parent-it</artifactId>
         <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-test-zendesk</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>2.4.1</cq-plugin.version>
+        <cq-plugin.version>2.4.2</cq-plugin.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.11.0</formatter-maven-plugin.version>

--- a/poms/bom-test/pom.xml
+++ b/poms/bom-test/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-integration-tests-support-azure</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -2682,12 +2682,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-azure-storage-blob</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-azure-storage-blob-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -2702,12 +2702,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-azure-storage-queue</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-azure-storage-queue-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -2842,12 +2842,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-cassandraql</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-cassandraql-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -5037,12 +5037,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-ahc</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-ahc-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -5067,12 +5067,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-azure-core</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-azure-core-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -5187,12 +5187,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-reactor-netty</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-support-reactor-netty-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -5297,12 +5297,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-telegram</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-telegram-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
@@ -5512,12 +5512,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-xml-io-dsl</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-xml-io-dsl-deployment</artifactId>
-                <version>${camel-quarkus-community.version}</version>
+                <version>${camel-quarkus.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>

--- a/product/README.adoc
+++ b/product/README.adoc
@@ -14,6 +14,8 @@
   This list actually controls which modules get unlinked from the source tree by `cq-prod-maven-plugin:prod-excludes` mojo.
 * `extensions.<artifactId>.allowedMixedTests` - if defined and set to a non-empty array of artifactIds,
   accept the mixed tests covering the given extension.
+* `extensions.<artifactId>.[jvm|native]` - The support status: possible values: `community`, `techPreview`, `supported`
+* `extensions.<artifactId>.comment` - A free form comment
 * `additionalProductizedArtifacts` - an array of artifactIds to include in the product build.
   Unlike `extensions.<artifactId>`, these are not extensions.
 

--- a/product/integration-tests-mixed-allowed/group-01/pom.xml
+++ b/product/integration-tests-mixed-allowed/group-01/pom.xml
@@ -39,7 +39,6 @@
         <module>../../../integration-tests/jms-artemis-client</module>
         <module>../../../integration-tests/jms-qpid-amqp-client</module>
         <module>../../../integration-tests/jta</module>
-        <module>../../../integration-tests/kamelet</module>
         <module>../../../integration-tests/microprofile</module>
         <module>../../../integration-tests/quartz</module>
     </modules>

--- a/product/integration-tests-mixed-allowed/pom.xml
+++ b/product/integration-tests-mixed-allowed/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus-product</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-tests-mixed-allowed</artifactId>

--- a/product/integration-tests-mixed-jvm/pom.xml
+++ b/product/integration-tests-mixed-jvm/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus-product</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-tests-mixed-jvm</artifactId>

--- a/product/integration-tests-mixed-native/group-01/pom.xml
+++ b/product/integration-tests-mixed-native/group-01/pom.xml
@@ -36,8 +36,6 @@
         <module>../../../integration-test-groups/aws2/aws2-cw</module>
         <module>../../../integration-test-groups/aws2/aws2-ses</module>
         <module>../../../integration-test-groups/azure/azure-eventhubs</module>
-        <module>../../../integration-test-groups/azure/azure-storage-blob</module>
-        <module>../../../integration-test-groups/azure/azure-storage-queue</module>
         <module>../../../integration-test-groups/foundation/browse</module>
         <module>../../../integration-test-groups/foundation/controlbus</module>
         <module>../../../integration-test-groups/foundation/core-fault-tolerance</module>
@@ -57,5 +55,6 @@
         <module>../../../integration-tests/aws2</module>
         <module>../../../integration-tests/base64</module>
         <module>../../../integration-tests/bean-validator</module>
+        <module>../../../integration-tests/box</module>
     </modules>
 </project>

--- a/product/integration-tests-mixed-native/group-02/pom.xml
+++ b/product/integration-tests-mixed-native/group-02/pom.xml
@@ -33,10 +33,8 @@
     <name>Camel Quarkus :: Integration Tests :: Mixed Native :: Group 02</name>
 
     <modules>
-        <module>../../../integration-tests/box</module>
         <module>../../../integration-tests/braintree</module>
         <module>../../../integration-tests/caffeine</module>
-        <module>../../../integration-tests/cassandraql</module>
         <module>../../../integration-tests/cbor</module>
         <module>../../../integration-tests/compression</module>
         <module>../../../integration-tests/consul</module>
@@ -57,5 +55,6 @@
         <module>../../../integration-tests/freemarker</module>
         <module>../../../integration-tests/geocoder</module>
         <module>../../../integration-tests/git</module>
+        <module>../../../integration-tests/github</module>
     </modules>
 </project>

--- a/product/integration-tests-mixed-native/group-03/pom.xml
+++ b/product/integration-tests-mixed-native/group-03/pom.xml
@@ -33,7 +33,6 @@
     <name>Camel Quarkus :: Integration Tests :: Mixed Native :: Group 03</name>
 
     <modules>
-        <module>../../../integration-tests/github</module>
         <module>../../../integration-tests/google</module>
         <module>../../../integration-tests/google-bigquery</module>
         <module>../../../integration-tests/google-pubsub</module>

--- a/product/integration-tests-mixed-native/group-04/pom.xml
+++ b/product/integration-tests-mixed-native/group-04/pom.xml
@@ -41,8 +41,6 @@
         <module>../../../integration-tests/main</module>
         <module>../../../integration-tests/main-caffeine-lrucache</module>
         <module>../../../integration-tests/main-collector</module>
-        <module>../../../integration-tests/main-devmode</module>
-        <module>../../../integration-tests/main-xml-io</module>
         <module>../../../integration-tests/main-xml-jaxb</module>
         <module>../../../integration-tests/micrometer</module>
         <module>../../../integration-tests/minio</module>
@@ -57,5 +55,6 @@
         <module>../../../integration-tests/openstack</module>
         <module>../../../integration-tests/opentelemetry</module>
         <module>../../../integration-tests/opentracing</module>
+        <module>../../../integration-tests/optaplanner</module>
     </modules>
 </project>

--- a/product/integration-tests-mixed-native/group-05/pom.xml
+++ b/product/integration-tests-mixed-native/group-05/pom.xml
@@ -33,7 +33,6 @@
     <name>Camel Quarkus :: Integration Tests :: Mixed Native :: Group 05</name>
 
     <modules>
-        <module>../../../integration-tests/optaplanner</module>
         <module>../../../integration-tests/paho</module>
         <module>../../../integration-tests/paho-mqtt5</module>
         <module>../../../integration-tests/pdf</module>

--- a/product/integration-tests-mixed-native/group-06/pom.xml
+++ b/product/integration-tests-mixed-native/group-06/pom.xml
@@ -41,7 +41,6 @@
         <module>../../../integration-tests/syndication</module>
         <module>../../../integration-tests/syslog</module>
         <module>../../../integration-tests/tarfile</module>
-        <module>../../../integration-tests/telegram</module>
         <module>../../../integration-tests/tika</module>
         <module>../../../integration-tests/twilio</module>
         <module>../../../integration-tests/twitter</module>

--- a/product/integration-tests-mixed-native/pom.xml
+++ b/product/integration-tests-mixed-native/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus-product</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-tests-mixed-native</artifactId>

--- a/product/integration-tests-product/group-01/pom.xml
+++ b/product/integration-tests-product/group-01/pom.xml
@@ -39,6 +39,8 @@
         <module>../../../integration-test-groups/aws2/aws2-lambda</module>
         <module>../../../integration-test-groups/aws2/aws2-s3</module>
         <module>../../../integration-test-groups/aws2/aws2-sqs-sns</module>
+        <module>../../../integration-test-groups/azure/azure-storage-blob</module>
+        <module>../../../integration-test-groups/azure/azure-storage-queue</module>
         <module>../../../integration-test-groups/foundation/bean</module>
         <module>../../../integration-test-groups/foundation/component-name-resolver</module>
         <module>../../../integration-test-groups/foundation/core</module>
@@ -54,10 +56,12 @@
         <module>../../../integration-test-groups/mongodb/mongodb</module>
         <module>../../../integration-tests/avro</module>
         <module>../../../integration-tests/bindy</module>
+        <module>../../../integration-tests/cassandraql</module>
         <module>../../../integration-tests/core-discovery-disabled</module>
         <module>../../../integration-tests/elasticsearch-rest</module>
         <module>../../../integration-tests/ftp</module>
         <module>../../../integration-tests/hl7</module>
         <module>../../../integration-tests/jackson-avro</module>
+        <module>../../../integration-tests/jackson-protobuf</module>
     </modules>
 </project>

--- a/product/integration-tests-product/group-02/pom.xml
+++ b/product/integration-tests-product/group-02/pom.xml
@@ -33,7 +33,6 @@
     <name>Camel Quarkus :: Integration Tests :: Product :: Group 02</name>
 
     <modules>
-        <module>../../../integration-tests/jackson-protobuf</module>
         <module>../../../integration-tests/jaxb</module>
         <module>../../../integration-tests/jira</module>
         <module>../../../integration-tests/jsonpath</module>
@@ -41,11 +40,14 @@
         <module>../../../integration-tests/kafka-sasl</module>
         <module>../../../integration-tests/kafka-sasl-ssl</module>
         <module>../../../integration-tests/kafka-ssl</module>
+        <module>../../../integration-tests/kamelet</module>
         <module>../../../integration-tests/kubernetes</module>
         <module>../../../integration-tests/main-command-mode</module>
+        <module>../../../integration-tests/main-devmode</module>
         <module>../../../integration-tests/main-discovery-disabled</module>
         <module>../../../integration-tests/main-unknown-args-fail</module>
         <module>../../../integration-tests/main-unknown-args-ignore</module>
+        <module>../../../integration-tests/main-xml-io</module>
         <module>../../../integration-tests/main-yaml</module>
         <module>../../../integration-tests/master</module>
         <module>../../../integration-tests/mllp</module>
@@ -58,6 +60,7 @@
         <module>../../../integration-tests/saxon</module>
         <module>../../../integration-tests/soap</module>
         <module>../../../integration-tests/sql</module>
+        <module>../../../integration-tests/telegram</module>
         <module>../../../integration-tests/xpath</module>
     </modules>
 </project>

--- a/product/integration-tests-product/pom.xml
+++ b/product/integration-tests-product/pom.xml
@@ -22,9 +22,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.camel.quarkus</groupId>
-        <artifactId>camel-quarkus-build-parent-it</artifactId>
+        <artifactId>camel-quarkus-product</artifactId>
         <version>2.2.0-SNAPSHOT</version>
-        <relativePath>../../poms/build-parent-it/pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>camel-quarkus-integration-tests-product</artifactId>

--- a/product/jenkinsfile-stage-template.txt
+++ b/product/jenkinsfile-stage-template.txt
@@ -3,6 +3,9 @@
                         label "rhel"
                     }
                     steps {
+                        unstash name: 'cq-artifacts'
+                        sh "mkdir -p /home/jenkins/.m2/repository/org/apache/camel/quarkus && mv -t /home/jenkins/.m2/repository/org/apache/camel/quarkus cq-artifacts.tgz"
+                        sh "cd /home/jenkins/.m2/repository/org/apache/camel/quarkus && tar xfz cq-artifacts.tgz"
                         configFileProvider([configFile(fileId: 'fuse-maven-settings', variable: 'MAVEN_SETTINGS')]) {
                             sh "cd ${groupDirectory} && ../../../mvnw ${MAVEN_PARAMS} test -fae"
                         }

--- a/product/src/main/groovy/generate-camel-quarkus-product-json.groovy
+++ b/product/src/main/groovy/generate-camel-quarkus-product-json.groovy
@@ -26,21 +26,45 @@ final Path basePath = project.basedir.toPath()
 final JsonSlurper jsonSlurper = new JsonSlurper()
 def productSourceJson = jsonSlurper.parse(basePath.resolve('src/main/resources/camel-quarkus-product-source.json'))
 def extensions = productSourceJson.extensions
-println "extensions = " + extensions
+// println "extensions = " + extensions
 
 def productJson = [:]
 
 productJson.extensions = []
 
 extensions.each { k, v ->
-    productJson.extensions << [
-        "group-id": "org.apache.camel.quarkus",
-        "artifact-id": k,
-        "metadata" : [
-            "redhat-support" : [ "supported" ]
+    final String quarkusSupportLevel = CqSupportStatus.valueOf(v.jvm).mergeForQuarkus(CqSupportStatus.valueOf(v.native))
+    if (quarkusSupportLevel != null) {
+        productJson.extensions << [
+            "group-id": "org.apache.camel.quarkus",
+            "artifact-id": k,
+            "metadata" : [
+                "redhat-support" : [ quarkusSupportLevel ]
+            ]
         ]
-    ]
+    }
 }
 final Path productJsonPath = basePath.resolve('target/camel-quarkus-product.json')
 Files.createDirectories(productJsonPath.getParent())
 Files.write(productJsonPath, JsonOutput.prettyPrint(JsonOutput.toJson(productJson)).getBytes('UTF-8'))
+
+
+enum CqSupportStatus {
+    community(null), techPreview('tech-preview'), supported('supported');
+    private final quarkusSupportLevel;
+    private CqSupportStatus(String quarkusSupportLevel) {
+        this.quarkusSupportLevel = quarkusSupportLevel;
+    }
+    public String mergeForQuarkus(CqSupportStatus native_) {
+        if (native_ == this) {
+            return quarkusSupportLevel;
+        }
+        if (this == CqSupportStatus.supported && native_ == CqSupportStatus.techPreview) {
+            return 'supported-in-jvm'
+        }
+        if (this == CqSupportStatus.techPreview && native_ == CqSupportStatus.community) {
+            return CqSupportStatus.community.quarkusSupportLevel
+        }
+        throw new IllegalStateException("Cannot merge native support level " + native_ + " with JVM supportlevel " + this);
+    }
+}

--- a/product/src/main/resources/camel-quarkus-product-source.json
+++ b/product/src/main/resources/camel-quarkus-product-source.json
@@ -1,225 +1,299 @@
 {
     "extensions": {
         "camel-quarkus-avro": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-ddb": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-kinesis": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-lambda": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-s3": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-sns": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-aws2-sqs": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
+        },
+        "camel-quarkus-azure-storage-blob": {
+            "jvm": "community",
+            "native": "community",
+            "comment": "Required by Camel K"
+        },
+        "camel-quarkus-azure-storage-queue": {
+            "jvm": "community",
+            "native": "community",
+            "comment": "Required by Camel K"
         },
         "camel-quarkus-bean": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-bindy": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
+        },
+        "camel-quarkus-cassandraql": {
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         },
         "camel-quarkus-core": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-cron": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "community",
+            "native": "community",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-quartz"
             ]
         },
         "camel-quarkus-direct": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-elasticsearch-rest": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-file": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-file"
             ]
         },
         "camel-quarkus-ftp": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-hl7": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-http": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-http"
             ]
         },
         "camel-quarkus-jackson": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-jackson-avro": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-jackson-protobuf": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-jacksonxml": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-dataformats-json"
             ]
         },
         "camel-quarkus-java-joor-dsl": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         },
         "camel-quarkus-jira": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-jms": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-jms-artemis-client",
                 "camel-quarkus-integration-test-jms-qpid-amqp-client"
             ]
         },
         "camel-quarkus-jsonpath": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-jta": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-jta"
             ]
         },
         "camel-quarkus-kafka": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-kamelet": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-kamelet"
             ]
         },
         "camel-quarkus-kubernetes": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         },
         "camel-quarkus-log": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-master": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         },
         "camel-quarkus-microprofile-health": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-microprofile-metrics": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0",
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": "",
             "allowedMixedTests": [
                 "camel-quarkus-integration-test-microprofile"
             ]
         },
         "camel-quarkus-mllp": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-mock": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-mongodb": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "techPreview",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-netty": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-openapi-java": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-platform-http": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-rest": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-salesforce": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-saxon": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-seda": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-soap": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-sql": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-support-webhook": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
+        },
+        "camel-quarkus-telegram": {
+            "jvm": "community",
+            "native": "community",
+            "comment": "Required by Camel K"
         },
         "camel-quarkus-timer": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
+        },
+        "camel-quarkus-xml-io-dsl": {
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         },
         "camel-quarkus-xpath": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "supported",
+            "native": "techPreview",
+            "comment": ""
         },
         "camel-quarkus-yaml-dsl": {
-            "jvmSupportedSince": "2.1.0",
-            "nativeSupportedSince": "2.1.0"
+            "jvm": "community",
+            "native": "community",
+            "comment": ""
         }
     },
     "additionalProductizedArtifacts": [


### PR DESCRIPTION
This solves the problem the productized part of the tree still required some non-productized artifacts via parent relationship. 
cc @cunningt 

I am preparing a similar patch for the upstream.