### PR TITLE
ENTESB-17507 AWS Aws2DdbQuarkusClientTest failed with 2.2.0.fuse-800016

### DIFF
--- a/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTestEnvCustomizer.java
+++ b/integration-test-groups/aws2-quarkus-client/aws2-ddb/src/test/java/org/apache/camel/quarkus/component/aws2/ddb/it/Aws2DdbTestEnvCustomizer.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 
 import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvContext;
 import org.apache.camel.quarkus.test.support.aws2.Aws2TestEnvCustomizer;
+import org.apache.camel.quarkus.test.support.aws2.Aws2TestResource;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -85,9 +86,12 @@ public class Aws2DdbTestEnvCustomizer implements Aws2TestEnvCustomizer {
         }
 
         Map<String, String> envContextProperties = envContext.getProperies();
-        String accessKey = envContextProperties.get("camel.component.aws2-ddb.access-key");
-        String secretKey = envContextProperties.get("camel.component.aws2-ddb.secret-key");
-        String region = envContextProperties.get("camel.component.aws2-ddb.region");
+        String accessKey = envContextProperties.getOrDefault("camel.component.aws2-ddb.access-key",
+                System.getenv(Aws2TestResource.AWS_ACCESS_KEY));
+        String secretKey = envContextProperties.getOrDefault("camel.component.aws2-ddb.secret-key",
+                System.getenv(Aws2TestResource.AWS_SECRET_KEY));
+        String region = envContextProperties.getOrDefault("camel.component.aws2-ddb.region",
+                System.getenv(Aws2TestResource.AWS_REGION));
 
         envContext.property("quarkus.dynamodb.aws.credentials.static-provider.access-key-id", accessKey);
         envContext.property("quarkus.dynamodb.aws.credentials.static-provider.secret-access-key", secretKey);

--- a/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
+++ b/integration-tests-support/aws2/src/main/java/org/apache/camel/quarkus/test/support/aws2/Aws2TestResource.java
@@ -37,14 +37,18 @@ import software.amazon.awssdk.core.SdkClient;
 public final class Aws2TestResource implements QuarkusTestResourceLifecycleManager {
     private static final Logger LOG = LoggerFactory.getLogger(Aws2TestResource.class);
 
+    public static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
+    public static final String AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    public static final String AWS_REGION = "AWS_REGION";
+
     private Aws2TestEnvContext envContext;
 
     @SuppressWarnings("resource")
     @Override
     public Map<String, String> start() {
-        final String realKey = System.getenv("AWS_ACCESS_KEY");
-        final String realSecret = System.getenv("AWS_SECRET_KEY");
-        final String realRegion = System.getenv("AWS_REGION");
+        final String realKey = System.getenv(AWS_ACCESS_KEY);
+        final String realSecret = System.getenv(AWS_SECRET_KEY);
+        final String realRegion = System.getenv(AWS_REGION);
         final boolean realCredentialsProvided = realKey != null && realSecret != null && realRegion != null;
         final boolean startMockBackend = MockBackendUtils.startMockBackend(false);
         final boolean usingMockBackend = startMockBackend && !realCredentialsProvided;


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/ENTESB-17507
Cherry-picked f7db6fdd5ea53daa18d3dfcbe455f39b367a7cde

PR fixes issue brought by https://github.com/jboss-fuse/camel-quarkus/commit/5cccaee532ba8978ecfb75b1ebaceb449c571054. Problem is caused when real AWS credentials are used. In that case customizer won't pass credentials to quarkus client.
The same problem has to be fixes also in `Aws2S3TestEnvCustomizer.java `.

@aldettinger (@ppalaga ) Do you think, that this is the right fix? If so, I'll extend it to `Aws2S3TestEnvCustomizer.java ` and switch this PR from draft.

<!-- Uncomment and fill this section if your PR is not trivial
[ ] An issue should be filed for the change unless this is a trivial change (fixing a typo or similar). One issue should ideally be fixed by not more than one commit and the other way round, each commit should fix just one issue, without pulling in other changes.
[ ] Each commit in the pull request should have a meaningful and properly spelled subject line and body. Copying the title of the associated issue is typically enough. Please include the issue number in the commit message prefixed by #.
[ ] The pull request description should explain what the pull request does, how, and why. If the info is available in the associated issue or some other external document, a link is enough.
[ ] Phrases like Fix #<issueNumber> or Fixes #<issueNumber> will auto-close the named issue upon merging the pull request. Using them is typically a good idea.
[ ] Please run mvn process-resources -Pformat (and amend the changes if necessary) before sending the pull request.
[ ] Contributor guide is your good friend: https://camel.apache.org/camel-quarkus/latest/contributor-guide.html
-->