### PR TITLE
Upgrade to cq-prod-maven-plugin 2.14.0 - normalize XML before comparing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>2.13.0</cq-plugin.version>
+        <cq-plugin.version>2.14.0</cq-plugin.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.11.0</formatter-maven-plugin.version>


### PR DESCRIPTION
@cunningt this is a nice to have for the QE so that their build from the gerrit tag does not fail. No respin required.