### PR TITLE
Add the test list to the list of artifacts to productize

### DIFF
--- a/product/src/main/generated/productized-camel-quarkus-artifacts.txt
+++ b/product/src/main/generated/productized-camel-quarkus-artifacts.txt
@@ -303,6 +303,7 @@ camel-quarkus-support-xstream-parent
 camel-quarkus-telegram
 camel-quarkus-telegram-deployment
 camel-quarkus-telegram-parent
+camel-quarkus-test-list
 camel-quarkus-timer
 camel-quarkus-timer-deployment
 camel-quarkus-timer-parent

--- a/product/src/main/resources/camel-quarkus-product-source.json
+++ b/product/src/main/resources/camel-quarkus-product-source.json
@@ -321,6 +321,7 @@
     },
     "additionalProductizedArtifacts": [
         "camel-quarkus-catalog",
-        "camel-quarkus-integration-tests-support-activemq"
+        "camel-quarkus-integration-tests-support-activemq",
+        "camel-quarkus-test-list"
     ]
 }

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -34,7 +34,7 @@
 
     <modules>
         <module>maven-plugin</module>
-        <!-- <module>test-list</module> disabled by cq-prod-maven-plugin:prod-excludes -->
+        <module>test-list</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-17760

I think the solution that we came to this morning was that we should try to add the test list to the quarkus platform temporarily, but add the the test list to the list of artifacts to productize in the case we have to do another build.    It might be good to get this change into the product branch so we don't forget about it.