### PR TITLE
Fixup 218bef4 Special fix for JMS extensions depending on

### DIFF
--- a/integration-tests/jms-qpid-amqp-client/pom.xml
+++ b/integration-tests/jms-qpid-amqp-client/pom.xml
@@ -135,6 +135,25 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>quarkus-platform</id>
+            <activation>
+                <property>
+                    <name>quarkus.platform.version</name>
+                </property>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.redhat.quarkus</groupId>
+                        <artifactId>quarkus-universe-bom</artifactId>
+                        <version>${quarkus.platform.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/sjms-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms-qpid-amqp-client/pom.xml
@@ -110,6 +110,25 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quarkus-platform</id>
+            <activation>
+                <property>
+                    <name>quarkus.platform.version</name>
+                </property>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.redhat.quarkus</groupId>
+                        <artifactId>quarkus-universe-bom</artifactId>
+                        <version>${quarkus.platform.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
     </profiles>
 
 </project>

--- a/integration-tests/sjms2-qpid-amqp-client/pom.xml
+++ b/integration-tests/sjms2-qpid-amqp-client/pom.xml
@@ -110,6 +110,25 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quarkus-platform</id>
+            <activation>
+                <property>
+                    <name>quarkus.platform.version</name>
+                </property>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.redhat.quarkus</groupId>
+                        <artifactId>quarkus-universe-bom</artifactId>
+                        <version>${quarkus.platform.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
quarkus-qpid-jms - Cannot run tests against alternative BOMs #3258

https://issues.redhat.com/browse/ENTESB-17789

Test modules only. No respin required.