### PR TITLE
Remove maven-exclude-extension from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,6 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-        <maven-exclude-extension.version>1.0.0.fuse-800004-redhat-00001</maven-exclude-extension.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -313,16 +312,6 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
-    <dependencyManagement>
-        <dependencies>
-          <dependency>
-             <groupId>org.jboss.fuse.maven</groupId>
-             <artifactId>maven-exclude-extension</artifactId>
-             <version>${maven-exclude-extension.version}</version>
-          </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/ENTESB-17876
maven-exclude-extension is showing up in https://issues.redhat.com/browse/ENTESB-17863 and we should remove it from the pom.xml as it is not being used.