### PR TITLE
ENTESB-17917: Fix AWS Lambda failing itest (bringing over commit by aldettinger)

### DIFF
--- a/integration-test-groups/aws2/aws2-lambda/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaResource.java
+++ b/integration-test-groups/aws2/aws2-lambda/src/main/java/org/apache/camel/quarkus/component/aws2/lambda/it/Aws2LambdaResource.java
@@ -101,13 +101,13 @@ public class Aws2LambdaResource {
                 .build();
     }
 
-    @Path("/function/get/{functionName}")
+    @Path("/function/getState/{functionName}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public String getFunction(@PathParam("functionName") String functionName) {
         return producerTemplate
                 .requestBody(componentUri(functionName, Lambda2Operations.getFunction), null, GetFunctionResponse.class)
-                .configuration().functionName();
+                .configuration().stateAsString();
     }
 
     @Path("/function/getArn/{functionName}")
@@ -129,7 +129,9 @@ public class Aws2LambdaResource {
                 .zipFile(SdkBytes.fromByteArray(zipFunctionBytes)).build();
         UpdateFunctionCodeResponse ufcResponse = producerTemplate.requestBody(uri, ufcRequest,
                 UpdateFunctionCodeResponse.class);
-        if (ufcResponse.lastUpdateStatus() == LastUpdateStatus.SUCCESSFUL) {
+
+        if (ufcResponse.lastUpdateStatus() == LastUpdateStatus.SUCCESSFUL
+                || ufcResponse.lastUpdateStatus() == LastUpdateStatus.IN_PROGRESS) {
             return Response.ok().build();
         }
         throw new IllegalStateException(


### PR DESCRIPTION
We rebranched 2.2.1-product, need to bring over the change from https://github.com/jboss-fuse/camel-quarkus/pull/115 