### PR TITLE
Update camel version and miscellaneous third party artifact versions to match the versions in camel 3.11.5

### DIFF
--- a/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
+++ b/integration-tests/mllp/src/test/java/org/apache/camel/quarkus/component/mllp/it/MllpTest.java
@@ -51,7 +51,7 @@ class MllpTest {
                 .body("invalidMessage")
                 .post("/mllp/send/invalid")
                 .then()
-                .statusCode(204);
+                .statusCode(500);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-dependencies</artifactId>
-        <version>3.11.1.fuse-800023</version>
+        <version>3.11.5.fuse-800003</version>
     </parent>
 
     <groupId>org.apache.camel.quarkus</groupId>
@@ -40,8 +40,8 @@
 
         <!-- Primary dependencies - maintained manually -->
         <camel.major.minor>3.11</camel.major.minor> <!-- run after each change: cd docs && mvnd validate -->
-        <camel-community.version>${camel.major.minor}.1</camel-community.version>
-        <camel.version>3.11.1.fuse-800023</camel.version>
+        <camel-community.version>${camel.major.minor}.5</camel-community.version>
+        <camel.version>3.11.5.fuse-800003</camel.version>
         <camel.docs.components.xref>${camel.major.minor}.x@components</camel.docs.components.xref><!-- the version in Camel's docs/components/antora.yml -->
         <camel.docs.branch>camel-${camel.major.minor}.x</camel.docs.branch><!-- The stable branch on which our Antora docs depends -->
 
@@ -76,14 +76,14 @@
         <eddsa.version>${eddsa-version}</eddsa.version>
         <freemarker.version>2.3.31</freemarker.version><!-- @sync io.quarkiverse.freemarker:quarkus-freemarker-parent:${quarkiverse.freemarker.version} prop:freemarker.version -->
         <fommil.netlib.core.version>1.1.2</fommil.netlib.core.version><!-- Mess in Weka transitive deps -->
-        <jodatime.version>2.10.6</jodatime.version><!-- Mess in transitive dependencies of Spark and Splunk -->
+        <jodatime.version>2.10.10</jodatime.version><!-- Mess in transitive dependencies of Spark and Splunk -->
         <github-api.version>1.111</github-api.version><!-- Used in a Groovy script bellow -->
         <guava.version>29.0-jre</guava.version>
         <graalvm.version>21.2.0.1-0-redhat-00002</graalvm.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.graalvm.nativeimage:svm -->
         <graalvm-community.version>21.2.0</graalvm-community.version><!-- keep in sync with graalvm.version -->
         <grpc.version>1.38.1.redhat-00001</grpc.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:io.grpc:grpc-core -->
         <grpc-community.version>1.38.1</grpc-community.version><!-- workaround https://github.com/apache/camel-quarkus/issues/3190 -->
-        <gson.version>2.8.6</gson.version><!-- @sync com.ibm.jsonata4java:JSONata4Java:${jsonata4java-version} dep:com.google.code.gson:gson -->
+        <gson.version>2.8.7</gson.version><!-- @sync com.ibm.jsonata4java:JSONata4Java:${jsonata4java-version} dep:com.google.code.gson:gson -->
         <hadoop2.version>${hadoop2-version}</hadoop2.version><!-- Spark -->
         <hapi.version>${hapi-version}</hapi.version>
         <hapi-fhir.version>${hapi-fhir-version}</hapi-fhir.version>
@@ -95,7 +95,7 @@
         <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version>
         <jcodings.version>1.0.55</jcodings.version><!-- used by hbase -->
         <joni.version>2.1.31</joni.version><!-- used by json-validator -->
-        <jsoup.version>1.12.1</jsoup.version><!-- used by oaipmh -->
+        <jsoup.version>1.13.1</jsoup.version><!-- used by oaipmh -->
         <jaxen.version>1.2.0</jaxen.version>
         <javassist.version>3.22.0-CR2</javassist.version><!-- debezium -->
         <jersey-sun.version>1.19.4</jersey-sun.version><!-- Spark -->
@@ -105,7 +105,7 @@
         <kafka.version>2.8.0.redhat-00003</kafka.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.kafka:kafka-clients -->
         <kudu.version>${kudu-version}</kudu.version>
         <kotlin.version>1.5.21</kotlin.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.jetbrains.kotlin:kotlin-stdlib -->
-        <log4j2.version>2.15.0</log4j2.version><!-- https://access.redhat.com/security/cve/CVE-2021-44228 can be removed when https://github.com/apache/camel-quarkus/pull/3378 reaches us in the upstream version we combine with -->
+        <log4j2.version>2.17.1</log4j2.version><!-- https://access.redhat.com/security/cve/CVE-2021-44228 can be removed when https://github.com/apache/camel-quarkus/pull/3378 reaches us in the upstream version we combine with -->
         <netty3.version>${netty3-version}</netty3.version><!-- Spark -->
         <minio.version>${minio-version}</minio.version><!-- Keep in sync with quarkiverse-minio and Camel, preferring Camel assuming that it is more likely to be up to date -->
         <mvel2.version>${mvel-version}</mvel2.version>
@@ -131,7 +131,7 @@
         <web3j.quorum.version>${web3j-quorum-version}</web3j.quorum.version>
         <woodstox-core.version>${woodstox-core-version}</woodstox-core.version>
         <zookeeper.version>${solr-zookeeper-version}</zookeeper.version><!-- ${solr-zookeeper-version} is newer than ${zookeeper-version} -->
-        <zxing.version>3.3.3</zxing.version><!-- Mess in IOTA transitive deps -->
+        <zxing.version>3.4.0</zxing.version><!-- Mess in IOTA transitive deps -->
 
         <!-- Test dependency versions (keep sorted alphabetically) -->
         <commons-logging.version>1.2</commons-logging.version><!-- Mess in the transitive dependencies of hbase-testing-util -->


### PR DESCRIPTION
- Update camel version to 3.11.5 (update both productized and community version)
- update log4j to 2.17.1
- update gson, jsoup, jodatime, zxing to match versions in camel 3.11.5 