### PR TITLE
ENTESB-17966 Add placeholder file for overrides in dependency alignment

### DIFF
--- a/product/src/main/generated/dependencies-to-skip-pme-alignment-on.txt
+++ b/product/src/main/generated/dependencies-to-skip-pme-alignment-on.txt
@@ -1,0 +1,6 @@
+# file format : groupId:artifactId
+# accept groupId:* as wildcard for all artifactId within groupId
+com.google.protobuf:* 
+org.eclipse.jetty:* 
+jakarta.activation:* 
+jakarta.xml.bind:*


### PR DESCRIPTION
Adding a placeholder for overrides in dependency alignment so we can get started on the groovy PME manipulation portion of ENTESB-17966 - is this location okay?    