### PR TITLE
Upgrade to cq-maven-plugin 2.18.0 - Generalize prod/non-prod classification over BOM groups

### DIFF
--- a/integration-tests/dataformats-json/pom.xml
+++ b/integration-tests/dataformats-json/pom.xml
@@ -181,6 +181,19 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.camel.quarkus</groupId>
+                    <artifactId>camel-quarkus-gson-deployment</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.camel.quarkus</groupId>
                     <artifactId>camel-quarkus-jackson-deployment</artifactId>
                     <version>${project.version}</version>
                     <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>2.17.0</cq-plugin.version>
+        <cq-plugin.version>2.18.0</cq-plugin.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.11.0</formatter-maven-plugin.version>
@@ -475,6 +475,9 @@
                                 </excludes>
                             </integrationTest>
                         </integrationTests>
+                        <additionalExtensionDependencies>
+                            <camel-quarkus-kudu>org.apache.kudu:kudu-client</camel-quarkus-kudu>
+                        </additionalExtensionDependencies>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -594,7 +594,7 @@
                         <dependency>
                             <groupId>org.apache.camel</groupId>
                             <artifactId>camel-buildtools</artifactId>
-                            <version>${camel.version}</version>
+                            <version>${camel-community.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -180,6 +180,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-as2-api</artifactId>
+                <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-asn1</artifactId>
                 <version>${camel-community.version}</version>
             </dependency>
@@ -518,6 +523,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-base-engine</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-base64</artifactId>
                 <version>${camel-community.version}</version>
             </dependency>
@@ -554,6 +564,11 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-box</artifactId>
+                <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-box-api</artifactId>
                 <version>${camel-community.version}</version>
             </dependency>
             <dependency>
@@ -604,6 +619,11 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-cloud</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-cluster</artifactId>
                 <version>${camel.version}</version>
             </dependency>
             <dependency>
@@ -684,7 +704,17 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-core-model</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-core-processor</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-core-reifier</artifactId>
                 <version>${camel.version}</version>
             </dependency>
             <dependency>
@@ -790,6 +820,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-dsl-support</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-ehcache</artifactId>
                 <version>${camel-community.version}</version>
             </dependency>
@@ -857,6 +892,11 @@
                         <artifactId>xpp3</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-fhir-api</artifactId>
+                <version>${camel-community.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1047,6 +1087,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-groovy-dsl-common</artifactId>
+                <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-grpc</artifactId>
                 <version>${camel-community.version}</version>
                 <exclusions>
@@ -1137,6 +1182,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-http-base</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-http-common</artifactId>
                 <version>${camel.version}</version>
             </dependency>
@@ -1181,6 +1231,11 @@
                         <artifactId>infinispan-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-infinispan-common</artifactId>
+                <version>${camel-community.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -1567,6 +1622,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-management-api</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-master</artifactId>
                 <version>${camel.version}</version>
             </dependency>
@@ -1728,6 +1788,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-olingo4-api</artifactId>
+                <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-openapi-java</artifactId>
                 <version>${camel.version}</version>
                 <exclusions>
@@ -1803,6 +1868,11 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-pgevent</artifactId>
                 <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-platform-http</artifactId>
+                <version>${camel.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -2163,6 +2233,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-tooling-model</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-tracing</artifactId>
+                <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-twilio</artifactId>
                 <version>${camel-community.version}</version>
             </dependency>
@@ -2178,6 +2258,16 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-util</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-util-json</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-validator</artifactId>
                 <version>${camel.version}</version>
             </dependency>
@@ -2190,6 +2280,11 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-vertx</artifactId>
                 <version>${camel-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-vertx-common</artifactId>
+                <version>${camel.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -2269,6 +2364,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
+                <artifactId>camel-xml-io-util</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
                 <artifactId>camel-xml-jaxb</artifactId>
                 <version>${camel.version}</version>
             </dependency>
@@ -2310,6 +2410,16 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-yaml-dsl</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-yaml-dsl-common</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-yaml-dsl-deserializers</artifactId>
                 <version>${camel.version}</version>
             </dependency>
             <dependency>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5877,17 +5877,6 @@
                 <version>${hapi-fhir.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-swf-libraries</artifactId>
-                <version>${awssdk1-swf-libs.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.amazonaws</groupId>
-                        <artifactId>aws-java-sdk-simpleworkflow</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
                 <version>${woodstox-core.version}</version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -6137,6 +6137,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
@@ -6147,22 +6152,17 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <version>${log4j2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-1.2-api</artifactId>
-                <version>${log4j2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jcl</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jul</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
             <dependency>
@@ -6226,14 +6226,14 @@
                 <version>${stax2.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hdrhistogram</groupId>
-                <artifactId>HdrHistogram</artifactId>
-                <version>${hdrhistogram.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.graalvm.js</groupId>
                 <artifactId>js</artifactId>
                 <version>${graalvm-community.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${hdrhistogram.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.influxdb</groupId>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5833,6 +5833,11 @@
             <!--$ Other third party dependencies $-->
             <dependency>
                 <groupId>ca.uhn.hapi</groupId>
+                <artifactId>hapi-base</artifactId>
+                <version>${hapi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi</groupId>
                 <artifactId>hapi-structures-v21</artifactId>
                 <version>${hapi.version}</version>
             </dependency>

--- a/product/src/main/generated/transitive-dependencies-all.txt
+++ b/product/src/main/generated/transitive-dependencies-all.txt
@@ -6,6 +6,14 @@ ai.djl.tensorflow:tensorflow-native-auto
 antlr:antlr
 backport-util-concurrent:backport-util-concurrent
 ca.uhn.hapi:hapi-base
+ca.uhn.hapi:hapi-structures-v21
+ca.uhn.hapi:hapi-structures-v22
+ca.uhn.hapi:hapi-structures-v23
+ca.uhn.hapi:hapi-structures-v231
+ca.uhn.hapi:hapi-structures-v24
+ca.uhn.hapi:hapi-structures-v25
+ca.uhn.hapi:hapi-structures-v251
+ca.uhn.hapi:hapi-structures-v26
 ca.uhn.hapi.fhir:hapi-fhir-base
 ca.uhn.hapi.fhir:hapi-fhir-client
 ca.uhn.hapi.fhir:hapi-fhir-server
@@ -842,6 +850,7 @@ org.aesh:readline
 org.amqphub.quarkus:quarkus-qpid-jms
 org.amqphub.quarkus:quarkus-qpid-jms-deployment
 org.antlr:ST4
+org.antlr:antlr
 org.antlr:antlr-runtime
 org.antlr:antlr4-runtime
 org.apache.abdera:abdera-core
@@ -926,6 +935,7 @@ org.apache.camel:camel-browse
 org.apache.camel:camel-caffeine
 org.apache.camel:camel-caffeine-lrucache
 org.apache.camel:camel-cassandraql
+org.apache.camel:camel-catalog
 org.apache.camel:camel-cbor
 org.apache.camel:camel-chatscript
 org.apache.camel:camel-chunk
@@ -939,6 +949,7 @@ org.apache.camel:camel-componentdsl
 org.apache.camel:camel-consul
 org.apache.camel:camel-controlbus
 org.apache.camel:camel-corda
+org.apache.camel:camel-core
 org.apache.camel:camel-core-catalog
 org.apache.camel:camel-core-engine
 org.apache.camel:camel-core-languages
@@ -1212,6 +1223,7 @@ org.apache.camel:camel-zip-deflater
 org.apache.camel:camel-zipfile
 org.apache.camel:camel-zookeeper
 org.apache.camel:camel-zookeeper-master
+org.apache.camel:spi-annotations
 org.apache.camel.quarkus:camel-quarkus-activemq
 org.apache.camel.quarkus:camel-quarkus-activemq-deployment
 org.apache.camel.quarkus:camel-quarkus-ahc
@@ -2034,7 +2046,14 @@ org.apache.kerby:kerby-pkix
 org.apache.kerby:kerby-util
 org.apache.kerby:kerby-xdr
 org.apache.kerby:token-provider
+org.apache.kudu:kudu-client
+org.apache.logging.log4j:log4j-1.2-api
 org.apache.logging.log4j:log4j-api
+org.apache.logging.log4j:log4j-core
+org.apache.logging.log4j:log4j-jcl
+org.apache.logging.log4j:log4j-jul
+org.apache.logging.log4j:log4j-slf4j-impl
+org.apache.logging.log4j:log4j-web
 org.apache.lucene:lucene-analyzers-common
 org.apache.lucene:lucene-core
 org.apache.lucene:lucene-highlighter

--- a/product/src/main/generated/transitive-dependencies-non-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-non-productized.txt
@@ -518,6 +518,7 @@ org.acplt.remotetea:remotetea-oncrpc
 org.amqphub.quarkus:quarkus-qpid-jms
 org.amqphub.quarkus:quarkus-qpid-jms-deployment
 org.antlr:ST4
+org.antlr:antlr
 org.antlr:antlr-runtime
 org.antlr:antlr4-runtime
 org.apache.abdera:abdera-core
@@ -1457,6 +1458,7 @@ org.apache.kerby:kerby-pkix
 org.apache.kerby:kerby-util
 org.apache.kerby:kerby-xdr
 org.apache.kerby:token-provider
+org.apache.kudu:kudu-client
 org.apache.lucene:lucene-analyzers-common
 org.apache.lucene:lucene-queryparser
 org.apache.lucene:lucene-sandbox

--- a/product/src/main/generated/transitive-dependencies-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-productized.txt
@@ -1,4 +1,12 @@
 ca.uhn.hapi:hapi-base
+ca.uhn.hapi:hapi-structures-v21
+ca.uhn.hapi:hapi-structures-v22
+ca.uhn.hapi:hapi-structures-v23
+ca.uhn.hapi:hapi-structures-v231
+ca.uhn.hapi:hapi-structures-v24
+ca.uhn.hapi:hapi-structures-v25
+ca.uhn.hapi:hapi-structures-v251
+ca.uhn.hapi:hapi-structures-v26
 com.atlassian.event:atlassian-event
 com.atlassian.httpclient:atlassian-httpclient-api
 com.atlassian.httpclient:atlassian-httpclient-library
@@ -341,9 +349,11 @@ org.apache.camel:camel-base-engine
 org.apache.camel:camel-bean
 org.apache.camel:camel-bindy
 org.apache.camel:camel-cassandraql
+org.apache.camel:camel-catalog
 org.apache.camel:camel-cloud
 org.apache.camel:camel-cluster
 org.apache.camel:camel-componentdsl
+org.apache.camel:camel-core
 org.apache.camel:camel-core-catalog
 org.apache.camel:camel-core-engine
 org.apache.camel:camel-core-languages
@@ -414,6 +424,7 @@ org.apache.camel:camel-xpath
 org.apache.camel:camel-yaml-dsl
 org.apache.camel:camel-yaml-dsl-common
 org.apache.camel:camel-yaml-dsl-deserializers
+org.apache.camel:spi-annotations
 org.apache.camel.quarkus:camel-quarkus-attachments
 org.apache.camel.quarkus:camel-quarkus-attachments-deployment
 org.apache.camel.quarkus:camel-quarkus-avro
@@ -575,7 +586,13 @@ org.apache.httpcomponents:httpcore
 org.apache.httpcomponents:httpcore-nio
 org.apache.httpcomponents:httpmime
 org.apache.kafka:kafka-clients
+org.apache.logging.log4j:log4j-1.2-api
 org.apache.logging.log4j:log4j-api
+org.apache.logging.log4j:log4j-core
+org.apache.logging.log4j:log4j-jcl
+org.apache.logging.log4j:log4j-jul
+org.apache.logging.log4j:log4j-slf4j-impl
+org.apache.logging.log4j:log4j-web
 org.apache.lucene:lucene-core
 org.apache.lucene:lucene-highlighter
 org.apache.lucene:lucene-join


### PR DESCRIPTION
Another set of improvements for https://issues.redhat.com/browse/ENTESB-17966