### PR TITLE
Incorrect version of quarkus-maven-plugin may be resolved #3520

### DIFF
--- a/integration-tests/avro/pom.xml
+++ b/integration-tests/avro/pom.xml
@@ -62,6 +62,7 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>
                     <execution>

--- a/integration-tests/messaging/pom.xml
+++ b/integration-tests/messaging/pom.xml
@@ -42,6 +42,7 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <id>build</id>

--- a/integration-tests/protobuf/pom.xml
+++ b/integration-tests/protobuf/pom.xml
@@ -62,6 +62,7 @@
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions><!-- Workaround for https://github.com/quarkusio/quarkus/issues/21718 -->
                 <executions>
                     <execution>


### PR DESCRIPTION
This should make it possible to run the build also on Maven 3.8.1