### PR TITLE
ENTESB-18691: Upgrade quarkus-jsch to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <quarkiverse-artemis.version>1.0.3</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
         <quarkiverse-freemarker.version>0.3.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-jgit.version>1.1.0</quarkiverse-jgit.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jgit/quarkus-jgit-parent/ -->
-        <quarkiverse-jsch.version>1.0.0</quarkiverse-jsch.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jsch/quarkus-jsch-parent/ -->
+        <quarkiverse-jsch.version>2.0.0</quarkiverse-jsch.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jsch/quarkus-jsch-parent/ -->
         <quarkiverse-minio.version>2.3.0</quarkiverse-minio.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/minio/quarkus-minio-parent/ -->
         <quarkiverse-tika.version>1.0.3</quarkiverse-tika.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/tika/quarkus-tika-parent/ -->
         <quarkus.version>2.7.5.Final-redhat-00011</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
@@ -118,7 +118,6 @@
         <jgit.version>6.0.0.202111291000-r</jgit.version><!-- @sync io.quarkiverse.jgit:quarkus-jgit-parent:${quarkiverse-jgit.version} prop:jgit.version -->
         <jnr-ffi.version>2.1.2</jnr-ffi.version><!-- Mess in web3j transitive deps -->
         <json-smart.version>2.4.7</json-smart.version>
-        <jzlib.version>1.1.3</jzlib.version><!-- @sync io.quarkiverse.jsch:quarkus-jsch-parent:${quarkiverse-jsch.version} prop:jzlib.version -->
         <kafka.version>3.1.0</kafka.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.apache.kafka:kafka-clients -->
         <kudu.version>${kudu-version}</kudu.version>
         <kotlin.version>1.6.10</kotlin.version><!-- @sync io.quarkus:quarkus-bom:${quarkus.version} dep:org.jetbrains.kotlin:kotlin-stdlib -->

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -10144,11 +10144,6 @@
                 <version>${graalvm.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-jboss-marshalling</artifactId>
-                <version>${infinispan.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.influxdb</groupId>
                 <artifactId>influxdb-java</artifactId>
                 <version>${influxdb.version}</version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -98,11 +98,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>com.jcraft</groupId>
-                <artifactId>jzlib</artifactId>
-                <version>${jzlib.version}</version>
-            </dependency>
 
             <!-- Dependencies a..z; do not remove this comment, it is important when sorting via  mvn process-resources -Pformat -->
 
@@ -2252,7 +2247,6 @@
                 <artifactId>camel-ftp</artifactId>
                 <version>${camel.version}</version>
                 <exclusions>
-                    <!-- TODO: Remove this https://github.com/apache/camel-quarkus/issues/3711 -->
                     <exclusion>
                         <groupId>com.github.mwiede</groupId>
                         <artifactId>jsch</artifactId>
@@ -3541,9 +3535,8 @@
                 <artifactId>camel-jsch</artifactId>
                 <version>${camel-community.version}</version>
                 <exclusions>
-                    <!-- TODO: Remove this https://github.com/apache/camel-quarkus/issues/3711 -->
                     <exclusion>
-                        <groupId>com.github.mwiede</groupId>
+                        <groupId>com.jcraft</groupId>
                         <artifactId>jsch</artifactId>
                     </exclusion>
                     <exclusion>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -52,11 +52,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.jcraft</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>jzlib</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-activemq</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.14.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -3488,7 +3483,7 @@
         <version>3.14.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
-            <groupId>com.github.mwiede</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <groupId>com.jcraft</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>jsch</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
           <exclusion>
@@ -9831,12 +9826,12 @@
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-jsch</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-jsch-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -10103,11 +10103,6 @@
         <version>21.3.2.0-1-redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>org.infinispan</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>infinispan-jboss-marshalling</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>13.0.6.Final</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>org.influxdb</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>influxdb-java</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>2.22</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -52,11 +52,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.jcraft</groupId>
-        <artifactId>jzlib</artifactId>
-        <version>1.1.3</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-activemq</artifactId>
         <version>3.14.2</version>
@@ -3488,7 +3483,7 @@
         <version>3.14.2</version>
         <exclusions>
           <exclusion>
-            <groupId>com.github.mwiede</groupId>
+            <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
           </exclusion>
           <exclusion>
@@ -9816,12 +9811,12 @@
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId>
         <artifactId>quarkus-jsch</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId>
         <artifactId>quarkus-jsch-deployment</artifactId>
-        <version>1.0.0</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.minio</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -52,11 +52,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.jcraft</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <artifactId>jzlib</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.1.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-      </dependency>
-      <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-activemq</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <version>3.14.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -3488,7 +3483,7 @@
         <version>3.14.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
-            <groupId>com.github.mwiede</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+            <groupId>com.jcraft</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
             <artifactId>jsch</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
           </exclusion>
           <exclusion>
@@ -9816,12 +9811,12 @@
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-jsch</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.jsch</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>quarkus-jsch-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.0.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.minio</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/product/src/main/generated/transitive-dependencies-all.txt
+++ b/product/src/main/generated/transitive-dependencies-all.txt
@@ -2311,7 +2311,6 @@ org.igniterealtime.smack:smack-tcp
 org.infinispan:infinispan-client-hotrod
 org.infinispan:infinispan-commons
 org.infinispan:infinispan-commons-test
-org.infinispan:infinispan-jboss-marshalling
 org.infinispan:infinispan-query-dsl
 org.infinispan:infinispan-remote-query-client
 org.infinispan:infinispan-server-testdriver-core

--- a/product/src/main/generated/transitive-dependencies-all.txt
+++ b/product/src/main/generated/transitive-dependencies-all.txt
@@ -166,6 +166,7 @@ com.github.mmazi:rescu
 com.github.multiformats:java-multiaddr
 com.github.multiformats:java-multibase
 com.github.multiformats:java-multihash
+com.github.mwiede:jsch
 com.github.openjson:openjson
 com.github.openstack4j.core:openstack4j-core
 com.github.openstack4j.core.connectors:openstack4j-okhttp

--- a/product/src/main/generated/transitive-dependencies-non-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-non-productized.txt
@@ -165,6 +165,8 @@ com.impossibl.pgjdbc-ng:pgjdbc-ng
 com.impossibl.pgjdbc-ng:spy
 com.jcabi:jcabi-log
 com.jcabi:jcabi-manifests
+com.jcraft:jsch
+com.jcraft:jzlib
 com.lmax:disruptor
 com.mattbertolini:liquibase-slf4j
 com.mchange:c3p0

--- a/product/src/main/generated/transitive-dependencies-non-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-non-productized.txt
@@ -1595,7 +1595,6 @@ org.igniterealtime.smack:smack-java7
 org.igniterealtime.smack:smack-resolver-javax
 org.igniterealtime.smack:smack-sasl-javax
 org.igniterealtime.smack:smack-tcp
-org.infinispan:infinispan-jboss-marshalling
 org.influxdb:influxdb-java
 org.iota:jota
 org.iq80.leveldb:leveldb

--- a/product/src/main/generated/transitive-dependencies-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-productized.txt
@@ -70,6 +70,7 @@ com.github.jnr:jnr-posix
 com.github.jnr:jnr-x86asm
 com.github.luben:zstd-jni
 com.github.mifmif:generex
+com.github.mwiede:jsch
 com.github.spotbugs:spotbugs-annotations
 com.github.stephenc.jcip:jcip-annotations
 com.google.code.gson:gson
@@ -83,8 +84,6 @@ com.google.oauth-client:google-oauth-client
 com.ibm.async:asyncutil
 com.ibm.icu:icu4j
 com.jayway.jsonpath:json-path
-com.jcraft:jsch
-com.jcraft:jzlib
 com.slack.api:slack-api-client
 com.slack.api:slack-api-model
 com.squareup:protoparser


### PR DESCRIPTION
Fixes:

* https://issues.redhat.com/browse/ENTESB-18691
* https://issues.redhat.com/browse/ENTESB-19064
* https://issues.redhat.com/browse/ENTESB-19016
* https://issues.redhat.com/browse/ENTESB-19015
