### PR TITLE
Avoid pulling javax.servlet:javax.servlet-api to MRRC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>2.27.1</cq-plugin.version>
+        <cq-plugin.version>2.28.0</cq-plugin.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.17.1</formatter-maven-plugin.version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -10385,63 +10385,84 @@
                                 <resolutionEntryPointInclude>org.apache.camel.quarkus:*</resolutionEntryPointInclude>
                                 <resolutionEntryPointInclude>ca.uhn.hapi:*</resolutionEntryPointInclude>
                             </resolutionEntryPointIncludes>
-                            <addExclusions>
-                                <addExclusion>
+                            <bomEntryTransformations>
+                                <bomEntryTransformation>
                                     <gavPattern>org.amqphub.quarkus:quarkus-qpid-jms</gavPattern>
-                                    <exclusions>org.apache.geronimo.specs:geronimo-jms_2.0_spec</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>org.apache.geronimo.specs:geronimo-jms_2.0_spec</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>com.datastax.oss:java-driver-core</gavPattern>
-                                    <exclusions>com.google.code.findbugs:jsr305</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>com.google.code.findbugs:jsr305</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>com.datastax.oss:java-driver-query-builder</gavPattern>
-                                    <exclusions>com.google.code.findbugs:jsr305</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>com.google.code.findbugs:jsr305</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>io.quarkiverse.minio:quarkus-minio</gavPattern>
-                                    <exclusions>com.google.code.findbugs:jsr305</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>com.google.code.findbugs:jsr305</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>software.amazon.awssdk:apache-client</gavPattern>
-                                    <exclusions>commons-logging:commons-logging</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>commons-logging:commons-logging</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>io.debezium:debezium-embedded:1.6.1.Final:jar</gavPattern>
-                                    <exclusions>javax.activation:activation,javax.servlet:javax.servlet-api,log4j:log4j,org.apache.kafka:kafka-log4j-appender,org.apache.kafka:connect-runtime,org.apache.kafka:connect-file</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>javax.activation:activation,javax.servlet:javax.servlet-api,log4j:log4j,org.apache.kafka:kafka-log4j-appender,org.apache.kafka:connect-runtime,org.apache.kafka:connect-file</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>org.glassfish.jaxb:jaxb-runtime</gavPattern>
-                                    <exclusions>jakarta.xml.bind:jakarta.xml.bind-api</exclusions>
-                                </addExclusion>
+                                    <addExclusions>jakarta.xml.bind:jakarta.xml.bind-api</addExclusions>
+                                </bomEntryTransformation>
+
+                                <bomEntryTransformation>
+                                    <gavPattern>org.apache.avro:avro-ipc-jetty</gavPattern>
+                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
+                                    <gavPattern>org.eclipse.jetty:jetty-security</gavPattern>
+                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
+                                    <gavPattern>org.eclipse.jetty:jetty-server</gavPattern>
+                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
+                                    <gavPattern>org.eclipse.jetty:jetty-servlet</gavPattern>
+                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
+                                    <gavPattern>org.eclipse.jetty:jetty-webapp</gavPattern>
+                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
+                                </bomEntryTransformation>
 
                                 <!-- Should go to quarkus-bom actually -->
-                                <addExclusion>
+                                <bomEntryTransformation>
                                     <gavPattern>com.google.http-client:google-http-client</gavPattern>
-                                    <exclusions>com.google.code.findbugs:jsr305</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>com.google.code.findbugs:jsr305</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>io.debezium:debezium-embedded</gavPattern>
-                                    <exclusions>javax.ws.rs:javax.ws.rs-api</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>javax.ws.rs:javax.ws.rs-api</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>io.grpc:grpc-netty</gavPattern>
-                                    <exclusions>com.google.code.findbugs:jsr305</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>com.google.code.findbugs:jsr305</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>org.apache.httpcomponents:*</gavPattern>
-                                    <exclusions>commons-logging:commons-logging</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>commons-logging:commons-logging</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>org.apache.kafka:connect-runtime</gavPattern>
-                                    <exclusions>javax.activation:activation,javax.servlet:javax.servlet-api,log4j:log4j</exclusions>
-                                </addExclusion>
-                                <addExclusion>
+                                    <addExclusions>javax.activation:activation,javax.servlet:javax.servlet-api,log4j:log4j</addExclusions>
+                                </bomEntryTransformation>
+                                <bomEntryTransformation>
                                     <gavPattern>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</gavPattern>
-                                    <exclusions>jakarta.activation:jakarta.activation-api,jakarta.xml.bind:jakarta.xml.bind-api</exclusions>
-                                </addExclusion>
+                                    <addExclusions>jakarta.activation:jakarta.activation-api,jakarta.xml.bind:jakarta.xml.bind-api</addExclusions>
+                                </bomEntryTransformation>
 
-                            </addExclusions>
+                            </bomEntryTransformations>
                         </configuration>
                     </execution>
                 </executions>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -9930,7 +9930,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>avro-ipc-jetty</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0.redhat-00002</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.11.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -21808,7 +21808,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-security</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21818,12 +21818,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-server</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-servlet</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21853,7 +21853,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-webapp</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.websocket</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -9915,7 +9915,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-ipc-jetty</artifactId>
-        <version>1.11.0.redhat-00002</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>
@@ -10577,17 +10577,17 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-security</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10607,7 +10607,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -9915,7 +9915,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>avro-ipc-jetty</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0.redhat-00002</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.11.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -10577,17 +10577,17 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-security</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-server</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-servlet</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10607,7 +10607,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-webapp</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->


### PR DESCRIPTION
Fix https://issues.redhat.com/browse/ENTESB-19003