### PR TITLE
ENTESB-19180 avro-ipc-netty and org.eclipse.jetty:* should not be

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>2.29.1</cq-plugin.version>
+        <cq-plugin.version>2.30.0</cq-plugin.version>
         <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <formatter-maven-plugin.version>2.17.1</formatter-maven-plugin.version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -10422,10 +10422,6 @@
                                 </bomEntryTransformation>
 
                                 <bomEntryTransformation>
-                                    <gavPattern>org.apache.avro:avro-ipc-jetty</gavPattern>
-                                    <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
-                                </bomEntryTransformation>
-                                <bomEntryTransformation>
                                     <gavPattern>org.eclipse.jetty:jetty-security</gavPattern>
                                     <versionReplacement>[\-\.]redhat-\d+$/</versionReplacement>
                                 </bomEntryTransformation>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -9941,7 +9941,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>avro-ipc-netty</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0.redhat-00002</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.11.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>javax.annotation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -10109,7 +10109,7 @@
       <dependency>
         <groupId>org.graalvm.js</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>js-scriptengine</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>21.3.2.0-1-redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>21.3.2.0-1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.influxdb</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -21580,12 +21580,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-alpn-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-alpn-java-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21635,7 +21635,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-continuation</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21689,22 +21689,22 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-common</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-hpack</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-http-client-transport</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21754,7 +21754,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-jmx</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21834,7 +21834,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-servlets</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -21899,7 +21899,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-xml</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>com.azure</groupId><!-- com.azure:azure-sdk-bom:1.0.5 -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -9926,7 +9926,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-ipc-netty</artifactId>
-        <version>1.11.0.redhat-00002</version>
+        <version>1.11.0</version>
         <exclusions>
           <exclusion>
             <groupId>javax.annotation</groupId>
@@ -10528,12 +10528,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-client</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-java-client</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10543,7 +10543,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-continuation</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10553,22 +10553,22 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-client</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-common</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-hpack</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId>
         <artifactId>http2-http-client-transport</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10578,7 +10578,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-jmx</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10598,7 +10598,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlets</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -10618,7 +10618,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-xml</artifactId>
-        <version>9.4.43.v20210629-redhat-00004</version>
+        <version>9.4.43.v20210629</version>
       </dependency>
       <dependency>
         <groupId>com.azure</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -9926,7 +9926,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>avro-ipc-netty</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.11.0.redhat-00002</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.11.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>javax.annotation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -10528,12 +10528,12 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-alpn-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-alpn-java-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10543,7 +10543,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-continuation</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10553,22 +10553,22 @@
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-client</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-common</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-hpack</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.http2</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>http2-http-client-transport</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10578,7 +10578,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-jmx</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10598,7 +10598,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-servlets</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
@@ -10618,7 +10618,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
         <artifactId>jetty-xml</artifactId><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
-        <version>9.4.43.v20210629-redhat-00004</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
+        <version>9.4.43.v20210629</version><!-- org.eclipse.jetty:jetty-bom:9.4.43.v20210629-redhat-00004 -->
       </dependency>
       <dependency>
         <groupId>com.azure</groupId><!-- com.azure:azure-sdk-bom:1.0.5 -->


### PR DESCRIPTION
managed at the product version in camel-quarkus-bom

https://issues.redhat.com/browse/ENTESB-19180