### PR TITLE
Pin fake-gcs-server container image to 1.37 tag

### DIFF
--- a/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageTestResource.java
+++ b/integration-tests/google-storage/src/test/java/org/apache/camel/quarkus/component/google/storage/it/GoogleStorageTestResource.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.GenericContainer;
 public class GoogleStorageTestResource implements QuarkusTestResourceLifecycleManager {
 
     public static final int PORT = AvailablePortFinder.getNextAvailable();
-    public static final String CONTAINER_NAME = "fsouza/fake-gcs-server";
+    public static final String CONTAINER_NAME = "fsouza/fake-gcs-server:1.37";
 
     private GenericContainer<?> container;
 


### PR DESCRIPTION
Google Storage tests are guaranteed to fail without this change.