### PR TITLE
Fix failing AWS SQS-SNS & OpenAPI Java tests

### DIFF
--- a/integration-test-groups/aws2/aws2-sqs-sns/src/main/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsResource.java
+++ b/integration-test-groups/aws2/aws2-sqs-sns/src/main/java/org/apache/camel/quarkus/component/aws2/sns/it/Aws2SqsSnsResource.java
@@ -88,11 +88,10 @@ public class Aws2SqsSnsResource extends BaseAws2Resource {
     @Consumes(MediaType.TEXT_PLAIN)
     @Produces(MediaType.TEXT_PLAIN)
     public Response snsSend(String message,
-            @QueryParam("queueUrl") String queueUrl,
             @DefaultValue("false") @QueryParam("fifo") boolean fifo) throws Exception {
 
         String endpointUri = String.format(
-                "aws2-sns://%s?useDefaultCredentialsProvider=%s&subscribeSNStoSQS=true&queueUrl=RAW(%s)%s",
+                "aws2-sns://%s?useDefaultCredentialsProvider=%s&subscribeSNStoSQS=true&queueArn=RAW(%s)%s",
                 fifo ? fifoTopicName : topicName, isUseDefaultCredentials(),
                 fifo ? snsFifoReceiverQueueArn : snsReceiverQueueArn,
                 fifo ? "&messageGroupIdStrategy=useExchangeId" : "");

--- a/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/common/OpenApiTest.java
+++ b/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/common/OpenApiTest.java
@@ -114,7 +114,7 @@ public abstract class OpenApiTest {
                 .statusCode(200)
                 .body(
                         "components.securitySchemes", hasKey("basicAuth"),
-                        "components.securitySchemes.basicAuth.name", is("basic"),
+                        "components.securitySchemes.basicAuth.scheme", is("basic"),
                         "components.securitySchemes.basicAuth.type", is("http"),
                         "components.securitySchemes.basicAuth.description", is("Basic Authentication"));
 

--- a/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3Test.java
+++ b/integration-tests/openapi-java/src/test/java/org/apache/camel/quarkus/component/openapijava/it/v3/OpenApiV3Test.java
@@ -46,7 +46,7 @@ public class OpenApiV3Test extends OpenApiTest {
                 .statusCode(200)
                 .body(
                         "components.securitySchemes", hasKey("bearerAuth"),
-                        "components.securitySchemes.bearerAuth.name", is("bearer"),
+                        "components.securitySchemes.bearerAuth.scheme", is("bearer"),
                         "components.securitySchemes.bearerAuth.type", is("http"),
                         "components.securitySchemes.bearerAuth.bearerFormat", is("Bearer Token Authentication"));
     }


### PR DESCRIPTION
cherry-picked some commits from upstream `camel-main` since some Camel changes got backported which broke some tests.