### PR TITLE
Upgrade to Quarkus CXF 1.5.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <optaplanner.version>8.29.0.Final</optaplanner.version><!-- May go back to Camel's ${optaplanner-version} when they are in sync https://repo1.maven.org/maven2/org/optaplanner/optaplanner-quarkus/ -->
         <quarkiverse-amazonservices.version>1.3.1</quarkiverse-amazonservices.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>2.0.1</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
-        <quarkiverse-cxf.version>1.5.14.redhat-00004</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
-        <quarkiverse-cxf-community.version>1.5.14</quarkiverse-cxf-community.version>
+        <quarkiverse-cxf.version>1.5.17</quarkiverse-cxf.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
+        <quarkiverse-cxf-community.version>1.5.17</quarkiverse-cxf-community.version>
         <quarkiverse-freemarker.version>0.3.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-jackson-jq.version>1.1.0</quarkiverse-jackson-jq.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jackson-jq/quarkus-jackson-jq-parent/ -->
         <quarkiverse-jgit.version>2.2.0</quarkiverse-jgit.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/jgit/quarkus-jgit-parent/ -->
@@ -92,7 +92,7 @@
         <commons-lang.version>2.6</commons-lang.version><!-- used by hbase, should be pretty stable as commons-lang is not developed actively anymore -->
         <commons-math3.version>3.6.1</commons-math3.version><!-- Mess in the transitive dependencies of Spark and hbase-testing-util -->
         <curator.version>4.3.0</curator.version><!-- Mess in the transitive dependencies of Spark, Zookeeper and other hadoop related components -->
-        <cxf.version>3.5.5.redhat-00029</cxf.version><!-- @sync io.quarkiverse.cxf:quarkus-cxf-parent:${quarkiverse-cxf.version} prop:cxf.version -->
+        <cxf.version>3.5.5</cxf.version><!-- @sync io.quarkiverse.cxf:quarkus-cxf-parent:${quarkiverse-cxf.version} prop:cxf.version -->
         <cxf.xjc-utils.version>3.3.2</cxf.xjc-utils.version><!-- @sync io.quarkiverse.cxf:quarkus-cxf-parent:${quarkiverse-cxf.version} prop:cxf.xjcplugins.version -->
         <eddsa.version>${eddsa-version}</eddsa.version>
         <freemarker.version>2.3.31</freemarker.version><!-- @sync io.quarkiverse.freemarker:quarkus-freemarker-parent:${quarkiverse-freemarker.version} prop:freemarker.version -->
@@ -115,9 +115,9 @@
         <jackson1.version>1.9.13</jackson1.version><!-- Mess in the transitive dependencies of hbase-testing-util -->
         <jackson-asl.version>${jackson1.version}</jackson-asl.version><!-- Can be different from jackson1.version on some occasions -->
         <jakarta.jms-api.version>2.0.3</jakarta.jms-api.version>
-        <jakarta.jws.ws.api.version>2.1.0.redhat-00001</jakarta.jws.ws.api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.jwsapi.version -->
-        <jakarta.xml.soap-api.version>1.4.2.redhat-00001</jakarta.xml.soap-api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.soapapi.version -->
-        <jakarta.xml.ws.api.version>2.3.3.redhat-00001</jakarta.xml.ws.api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.wsapi.version -->
+        <jakarta.jws.ws.api.version>2.1.0</jakarta.jws.ws.api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.jwsapi.version -->
+        <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.soapapi.version -->
+        <jakarta.xml.ws.api.version>2.3.3</jakarta.xml.ws.api.version><!-- @sync org.apache.cxf:cxf-parent:${cxf.version} prop:cxf.jakarta.wsapi.version -->
         <java-json-tools.json-patch.version>${json-patch-version}</java-json-tools.json-patch.version><!-- A replacement for com.github.fge:json-patch -->
         <jcodings.version>1.0.55</jcodings.version><!-- used by hbase -->
         <jodatime.version>2.10.6</jodatime.version><!-- Mess in transitive dependencies of Spark and Splunk -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -10,9 +10,9 @@
   <url>http://camel.apache.org/camel-quarkus-poms/camel-quarkus-bom</url>
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name><!-- org.apache:apache:23 -->
-      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url><!-- org.apache:apache:23 -->
-      <distribution>repo</distribution><!-- org.apache:apache:23 -->
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
   <developers>
@@ -39,14 +39,14 @@
   </issueManagement>
   <distributionManagement>
     <repository>
-      <id>apache.releases.https</id><!-- org.apache:apache:23 -->
-      <name>Apache Release Distribution Repository</name><!-- org.apache:apache:23 -->
-      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url><!-- org.apache:apache:23 -->
+      <id>apache.releases.https</id>
+      <name>Apache Release Distribution Repository</name>
+      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
-      <id>apache.snapshots.https</id><!-- org.apache:apache:23 -->
-      <name>Apache Development Snapshot Repository</name><!-- org.apache:apache:23 -->
-      <url>https://repository.apache.org/content/repositories/snapshots</url><!-- org.apache:apache:23 -->
+      <id>apache.snapshots.https</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
   <dependencyManagement>
@@ -6643,7 +6643,7 @@
       <dependency>
         <groupId>jakarta.xml.soap</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jakarta.xml.soap-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.4.2.redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.4.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -6654,7 +6654,7 @@
       <dependency>
         <groupId>jakarta.xml.ws</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jakarta.xml.ws-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.3.3.redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.3.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -7075,446 +7075,446 @@
         <version>2.12.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>spring-context</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>spring-context</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>6.5.1.redhat-00005</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.3.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.2.0.redhat-00001</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>4.2.1.redhat-00006</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId>
@@ -7523,213 +7523,218 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.10.0.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>2.1.0.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>2.3.3.redhat-00006</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>2.3.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.1.2.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.1.2.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -6643,7 +6643,7 @@
       <dependency>
         <groupId>jakarta.xml.soap</groupId>
         <artifactId>jakarta.xml.soap-api</artifactId>
-        <version>1.4.2.redhat-00001</version>
+        <version>1.4.2</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -6654,7 +6654,7 @@
       <dependency>
         <groupId>jakarta.xml.ws</groupId>
         <artifactId>jakarta.xml.ws-api</artifactId>
-        <version>2.3.3.redhat-00001</version>
+        <version>2.3.3</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId>
@@ -7057,7 +7057,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-core</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7076,7 +7076,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-features-logging</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7098,7 +7098,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxws</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7113,7 +7113,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-http</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7139,7 +7139,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-mex</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7150,7 +7150,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-security</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7184,7 +7184,7 @@
       <dependency>
         <groupId>org.apache.cxf.services.sts</groupId>
         <artifactId>cxf-services-sts-core</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7199,7 +7199,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-wsdlto-core</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7218,7 +7218,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7229,7 +7229,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7240,7 +7240,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-common</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7255,7 +7255,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-validator</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7270,7 +7270,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-wsdl</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7370,122 +7370,122 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>1.5.14</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>1.5.14.redhat-00004</version>
+        <version>1.5.17</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
-        <version>6.5.1.redhat-00005</version>
+        <version>6.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.messaging.saaj</groupId>
         <artifactId>saaj-impl</artifactId>
-        <version>1.5.3.redhat-00004</version>
+        <version>1.5.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.neethi</groupId>
         <artifactId>neethi</artifactId>
-        <version>3.2.0.redhat-00001</version>
+        <version>3.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
-        <version>4.2.1.redhat-00006</version>
+        <version>4.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.ehcache</groupId>
@@ -7505,17 +7505,22 @@
       <dependency>
         <groupId>org.jvnet.mimepull</groupId>
         <artifactId>mimepull</artifactId>
-        <version>1.10.0.redhat-00003</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>jakarta.jws</groupId>
         <artifactId>jakarta.jws-api</artifactId>
-        <version>2.1.0.redhat-00003</version>
+        <version>2.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>wsdl4j</groupId>
+        <artifactId>wsdl4j</artifactId>
+        <version>1.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
-        <version>2.3.3.redhat-00006</version>
+        <version>2.3.4</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7530,12 +7535,12 @@
       <dependency>
         <groupId>io.quarkiverse.xmlsec</groupId>
         <artifactId>quarkus-xmlsec</artifactId>
-        <version>1.1.2.redhat-00003</version>
+        <version>1.1.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.xmlsec</groupId>
         <artifactId>quarkus-xmlsec-deployment</artifactId>
-        <version>1.1.2.redhat-00003</version>
+        <version>1.1.3</version>
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
@@ -7546,7 +7551,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-bindings-soap</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7557,7 +7562,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-bindings-xml</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7568,7 +7573,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-databinding-aegis</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7579,7 +7584,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-databinding-jaxb</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7590,7 +7595,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-simple</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7601,7 +7606,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-javascript</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7623,7 +7628,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-json-basic</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7634,18 +7639,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-security-jose</artifactId>
-        <version>3.5.5.redhat-00029</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-security</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7656,7 +7650,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-security-saml</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7675,7 +7669,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-addr</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -7686,7 +7680,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-ws-policy</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId>
@@ -7704,8 +7698,19 @@
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-security</artifactId>
+        <version>3.5.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-tools-java2ws</artifactId>
-        <version>3.5.5.redhat-00029</version>
+        <version>3.5.5</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -10,9 +10,9 @@
   <url>http://camel.apache.org/camel-quarkus-poms/camel-quarkus-bom</url>
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name><!-- org.apache:apache:23 -->
-      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url><!-- org.apache:apache:23 -->
-      <distribution>repo</distribution><!-- org.apache:apache:23 -->
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
   <developers>
@@ -39,14 +39,14 @@
   </issueManagement>
   <distributionManagement>
     <repository>
-      <id>apache.releases.https</id><!-- org.apache:apache:23 -->
-      <name>Apache Release Distribution Repository</name><!-- org.apache:apache:23 -->
-      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url><!-- org.apache:apache:23 -->
+      <id>apache.releases.https</id>
+      <name>Apache Release Distribution Repository</name>
+      <url>https://repository.apache.org/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
-      <id>apache.snapshots.https</id><!-- org.apache:apache:23 -->
-      <name>Apache Development Snapshot Repository</name><!-- org.apache:apache:23 -->
-      <url>https://repository.apache.org/content/repositories/snapshots</url><!-- org.apache:apache:23 -->
+      <id>apache.snapshots.https</id>
+      <name>Apache Development Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
   <dependencyManagement>
@@ -6643,7 +6643,7 @@
       <dependency>
         <groupId>jakarta.xml.soap</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jakarta.xml.soap-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>1.4.2.redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>1.4.2</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.activation</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -6654,7 +6654,7 @@
       <dependency>
         <groupId>jakarta.xml.ws</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jakarta.xml.ws-api</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.3.3.redhat-00001</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.3.3</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <exclusions>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -7055,446 +7055,446 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>spring-context</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.springframework</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>spring-context</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.3.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-transports-http-hc5-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.14.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.17</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>6.5.1.redhat-00005</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>6.5.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.5.3.redhat-00004</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.5.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.2.0.redhat-00001</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.2.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>4.2.1.redhat-00006</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>4.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.10.8</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
             <groupId>jakarta.xml.bind</groupId>
@@ -7503,213 +7503,218 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.10.0.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>2.1.0.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>jakarta.jws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>jakarta.jws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>2.1.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>2.3.3.redhat-00006</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+      </dependency>
+      <dependency>
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>2.3.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
           <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.1.2.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>1.1.2.redhat-00003</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>io.quarkiverse.xmlsec</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>quarkus-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>1.1.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.javamail</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-javamail_1.4_mail</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>jakarta.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.activation-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>jakarta.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>jakarta.xml.bind-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-        <version>3.5.5.redhat-00029</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+        <version>3.5.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
-            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.14.redhat-00004 -->
+            <groupId>org.apache.geronimo.specs</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
+            <artifactId>geronimo-jta_1.1_spec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:1.5.17 -->
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
The current PR fixes https://issues.redhat.com/browse/CEQ-8389 (2.13)

... and there is a related issue for 3.2 https://issues.redhat.com/browse/CEQ-8392

Filling this as a draft because CXF 1.5.17 should be productized and the productized version should be used before merging