### PR TITLE
CEQ-10314: Disable combineUnicodeSurrogatres feature if COMBINE_UNICODE_SURROGATES_IN_UTF8 enum is not present in Jackson

### DIFF
--- a/extensions/jackson/deployment/src/main/java/org/apache/camel/quarkus/component/jackson/JacksonProcessor.java
+++ b/extensions/jackson/deployment/src/main/java/org/apache/camel/quarkus/component/jackson/JacksonProcessor.java
@@ -17,12 +17,21 @@
 package org.apache.camel.quarkus.component.jackson;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.BytecodeTransformerBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.gizmo.Gizmo;
+import org.apache.camel.component.jackson.AbstractJacksonDataFormat;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 public class JacksonProcessor {
 
@@ -45,5 +54,54 @@ public class JacksonProcessor {
             items.add(ReflectiveClassBuildItem.builder("org.joda.time.DateTime").build());
         }
         return items;
+    }
+
+    @BuildStep(onlyIf = JacksonCombineUnicodeSurrogatesAbsent.class)
+    BytecodeTransformerBuildItem transformMethodConfigureCombineUnicodeSurrogates() {
+        String message = "The combineUnicodeSurrogates option is not supported on Camel Quarkus";
+
+        // Rewrites AbstractJacksonDataFormat.configureCombineUnicodeSurrogates to:
+        //
+        // protected ObjectWriter configureCombineUnicodeSurrogates(ObjectWriter objectWriter) {
+        //    throw new IllegalStateException("The combineUnicodeSurrogates option is not supported on Camel Quarkus");
+        // }
+        return new BytecodeTransformerBuildItem.Builder()
+                .setClassToTransform(AbstractJacksonDataFormat.class.getName())
+                .setCacheable(true)
+                .setVisitorFunction((className, classVisitor) -> {
+                    return new ClassVisitor(Gizmo.ASM_API_VERSION, classVisitor) {
+                        @Override
+                        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                                String[] exceptions) {
+                            MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                            if (name.equals("configureCombineUnicodeSurrogates")) {
+                                return new MethodVisitor(Gizmo.ASM_API_VERSION, methodVisitor) {
+                                    @Override
+                                    public void visitCode() {
+                                        super.visitCode();
+                                        mv.visitLdcInsn(message);
+                                        mv.visitTypeInsn(Opcodes.NEW, "java/lang/IllegalStateException");
+                                        mv.visitInsn(Opcodes.DUP);
+                                        mv.visitLdcInsn(message);
+                                        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/IllegalStateException",
+                                                "<init>", "(Ljava/lang/String;)V", false);
+                                        mv.visitInsn(Opcodes.ATHROW);
+                                    }
+                                };
+                            }
+                            return methodVisitor;
+                        }
+                    };
+                })
+                .build();
+    }
+
+    static final class JacksonCombineUnicodeSurrogatesAbsent implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            JsonWriteFeature[] enumConstants = JsonWriteFeature.class.getEnumConstants();
+            return Arrays.stream(enumConstants)
+                    .noneMatch(enumEntry -> enumEntry.toString().equals("COMBINE_UNICODE_SURROGATES_IN_UTF8"));
+        }
     }
 }

--- a/extensions/mongodb/deployment/pom.xml
+++ b/extensions/mongodb/deployment/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-jackson-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
             <artifactId>camel-quarkus-mongodb</artifactId>
         </dependency>
     </dependencies>

--- a/extensions/mongodb/runtime/pom.xml
+++ b/extensions/mongodb/runtime/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>camel-quarkus-support-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-jackson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mongodb</artifactId>
         </dependency>


### PR DESCRIPTION
I'll push the changes to the mongodb extension upstream later today.