### PR TITLE
Add configuration support for FileLockClusterService heartbeat-timeout-multiplier option

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/file-cluster-service.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/file-cluster-service.adoc
@@ -115,6 +115,16 @@ a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-acquire-lock
 The time to wait between attempts to try to acquire lock (defaults to 10000ms).
 | `string`
 | 
+
+a|icon:lock[title=Fixed at build time] [[quarkus-camel-cluster-file-heartbeat-timeout-multiplier]]`link:#quarkus-camel-cluster-file-heartbeat-timeout-multiplier[quarkus.camel.cluster.file.heartbeat-timeout-multiplier]`
+
+Multiplier applied to the cluster leader `acquireLockInterval` to determine how long followers should wait
+before considering the leader "stale".
+
+For example, if the leader updates its heartbeat every 2 seconds and the `heartbeatTimeoutMultiplier` is `3`,
+followers will tolerate up to `2s * 3 = 6s` of silence before declaring the leader unavailable.
+| `int`
+| 
 |===
 
 [.configuration-legend]

--- a/extensions/file-cluster-service/deployment/src/test/java/org/apache/camel/quarkus/component/file/cluster/deployment/FileLockClusterServiceConfigDefaultEnabledTest.java
+++ b/extensions/file-cluster-service/deployment/src/test/java/org/apache/camel/quarkus/component/file/cluster/deployment/FileLockClusterServiceConfigDefaultEnabledTest.java
@@ -84,5 +84,6 @@ public class FileLockClusterServiceConfigDefaultEnabledTest {
         assertEquals(TimeUnit.SECONDS, service.getAcquireLockDelayUnit());
         assertEquals(10L, service.getAcquireLockInterval());
         assertEquals(TimeUnit.SECONDS, service.getAcquireLockIntervalUnit());
+        assertEquals(5, service.getHeartbeatTimeoutMultiplier());
     }
 }

--- a/extensions/file-cluster-service/deployment/src/test/java/org/apache/camel/quarkus/component/file/cluster/deployment/FileLockClusterServiceConfigNonDefaultEnabledTest.java
+++ b/extensions/file-cluster-service/deployment/src/test/java/org/apache/camel/quarkus/component/file/cluster/deployment/FileLockClusterServiceConfigNonDefaultEnabledTest.java
@@ -55,6 +55,7 @@ public class FileLockClusterServiceConfigNonDefaultEnabledTest {
         props.setProperty("quarkus.camel.cluster.file.attributes.key2", "value2");
         props.setProperty("quarkus.camel.cluster.file.acquire-lock-delay", "5");
         props.setProperty("quarkus.camel.cluster.file.acquire-lock-interval", "1h");
+        props.setProperty("quarkus.camel.cluster.file.heartbeat-timeout-multiplier", "1");
 
         try {
             props.store(writer, "");
@@ -93,5 +94,7 @@ public class FileLockClusterServiceConfigNonDefaultEnabledTest {
         assertEquals(TimeUnit.MILLISECONDS, service.getAcquireLockDelayUnit());
         assertEquals(3600000, service.getAcquireLockInterval());
         assertEquals(TimeUnit.MILLISECONDS, service.getAcquireLockIntervalUnit());
+
+        assertEquals(1, service.getHeartbeatTimeoutMultiplier());
     }
 }

--- a/extensions/file-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/file/cluster/FileLockClusterServiceConfig.java
+++ b/extensions/file-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/file/cluster/FileLockClusterServiceConfig.java
@@ -82,6 +82,17 @@ public interface FileLockClusterServiceConfig {
      */
     Optional<String> acquireLockInterval();
 
+    /**
+     * Multiplier applied to the cluster leader `acquireLockInterval` to determine how long followers should wait
+     * before considering the leader "stale".
+     *
+     * For example, if the leader updates its heartbeat every 2 seconds and the `heartbeatTimeoutMultiplier` is `3`,
+     * followers will tolerate up to `2s * 3 = 6s` of silence before declaring the leader unavailable.
+     *
+     * @asciidoclet
+     */
+    Optional<Integer> heartbeatTimeoutMultiplier();
+
     final class Enabled implements BooleanSupplier {
         FileLockClusterServiceConfig config;
 

--- a/extensions/file-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/file/cluster/FileLockClusterServiceRecorder.java
+++ b/extensions/file-cluster-service/runtime/src/main/java/org/apache/camel/quarkus/component/file/cluster/FileLockClusterServiceRecorder.java
@@ -37,6 +37,7 @@ public class FileLockClusterServiceRecorder {
         config.acquireLockInterval().ifPresent(interval -> {
             flcs.setAcquireLockInterval(TimePatternConverter.toMilliSeconds(interval), TimeUnit.MILLISECONDS);
         });
+        config.heartbeatTimeoutMultiplier().ifPresent(flcs::setHeartbeatTimeoutMultiplier);
 
         config.attributes().forEach(flcs::setAttribute);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CEQ-11650

Depends on this companion Camel PR: https://github.com/jboss-fuse/camel/pull/2867