### PR TITLE
CEQ-11848: Use camel-quarkus-opentelemetry instead of camel-quarkus-opentelemetry2 in observability-services extension

### DIFF
--- a/docs/modules/ROOT/pages/reference/extensions/observability-services.adoc
+++ b/docs/modules/ROOT/pages/reference/extensions/observability-services.adoc
@@ -64,7 +64,7 @@ This extension automatically provides the following Camel Quarkus component exte
 * xref:reference/extensions/microprofile-health.adoc[Camel Quarkus MicroProfile Health] - for health checks
 * xref:reference/extensions/management.adoc[Camel Quarkus Management] - for JMX
 * xref:reference/extensions/micrometer.adoc[Camel Quarkus Micrometer] - for Camel Micrometer metrics
-* xref:reference/extensions/opentelemetry2.adoc[Camel Quarkus OpenTelemetry2] - for tracing Camel messages (events/spans)
+* xref:reference/extensions/opentelemetry.adoc[Camel Quarkus OpenTelemetry] - for tracing Camel messages (events/spans)
 * https://quarkus.io/guides/telemetry-micrometer#micrometer-and-monitoring-system-extensions[Quarkus Micrometer Registry Prometheus] - for exporting metrics in Prometheus format
 
 [id="extensions-observability-services-usage-list-of-known-endpoints"]

--- a/extensions/observability-services/deployment/pom.xml
+++ b/extensions/observability-services/deployment/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-opentelemetry2-deployment</artifactId>
+            <artifactId>camel-quarkus-opentelemetry-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/extensions/observability-services/runtime/pom.xml
+++ b/extensions/observability-services/runtime/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>
-            <artifactId>camel-quarkus-opentelemetry2</artifactId>
+            <artifactId>camel-quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.quarkus</groupId>

--- a/extensions/observability-services/runtime/src/main/doc/usage.adoc
+++ b/extensions/observability-services/runtime/src/main/doc/usage.adoc
@@ -15,7 +15,7 @@ This extension automatically provides the following Camel Quarkus component exte
 * xref:reference/extensions/microprofile-health.adoc[Camel Quarkus MicroProfile Health] - for health checks
 * xref:reference/extensions/management.adoc[Camel Quarkus Management] - for JMX
 * xref:reference/extensions/micrometer.adoc[Camel Quarkus Micrometer] - for Camel Micrometer metrics
-* xref:reference/extensions/opentelemetry2.adoc[Camel Quarkus OpenTelemetry2] - for tracing Camel messages (events/spans)
+* xref:reference/extensions/opentelemetry.adoc[Camel Quarkus OpenTelemetry] - for tracing Camel messages (events/spans)
 * https://quarkus.io/guides/telemetry-micrometer#micrometer-and-monitoring-system-extensions[Quarkus Micrometer Registry Prometheus] - for exporting metrics in Prometheus format
 
 === List of known endpoints

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -210,7 +210,7 @@
         <module>openapi-java</module>
         <!-- <module>openstack</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>opentelemetry</module>
-        <module>opentelemetry2</module>
+        <!-- <module>opentelemetry2</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <!-- <module>optaplanner</module> disabled by cq-prod-maven-plugin:prod-excludes -->
         <module>paho</module>
         <module>paho-mqtt5</module>

--- a/integration-tests/observability-services/src/test/java/org/apache/camel/quarkus/component/observabilityservices/it/ObservabilityServicesTest.java
+++ b/integration-tests/observability-services/src/test/java/org/apache/camel/quarkus/component/observabilityservices/it/ObservabilityServicesTest.java
@@ -102,22 +102,25 @@ class ObservabilityServicesTest {
 
             await().atMost(30, TimeUnit.SECONDS).pollDelay(50, TimeUnit.MILLISECONDS).until(() -> getSpans().size() == 5);
             List<Map<String, String>> spans = getSpans();
-
             assertEquals(spans.get(0).get("parentId"), spans.get(1).get("spanId"));
             assertEquals("seda://next", spans.get(0).get("camel.uri"));
             assertEquals("INTERNAL", spans.get(0).get("kind"));
 
             assertEquals(spans.get(1).get("parentId"), spans.get(2).get("spanId"));
             assertEquals("seda://next", spans.get(1).get("camel.uri"));
-            assertEquals("INTERNAL", spans.get(1).get("kind"));
+            assertEquals("CLIENT", spans.get(1).get("kind"));
 
             assertEquals(spans.get(2).get("parentId"), spans.get(3).get("spanId"));
             assertEquals("direct://start", spans.get(2).get("camel.uri"));
             assertEquals("INTERNAL", spans.get(2).get("kind"));
 
-            assertEquals("0000000000000000", spans.get(3).get("parentId"));
+            assertEquals(spans.get(3).get("parentId"), spans.get(4).get("spanId"));
             assertEquals("direct://start", spans.get(3).get("camel.uri"));
-            assertEquals("INTERNAL", spans.get(3).get("kind"));
+            assertEquals("CLIENT", spans.get(3).get("kind"));
+
+            assertEquals("0000000000000000", spans.get(4).get("parentId"));
+            assertEquals("trace", spans.get(4).get("code.function"));
+            assertEquals("/observability-services/trace", spans.get(4).get("url.path"));
         } finally {
             RestAssured.given()
                     .post("/spans/reset")

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -2314,7 +2314,7 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-opentelemetry2</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -2862,7 +2862,7 @@
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-telemetry</artifactId>
-                <version>${camel.version}</version>
+                <version>${camel-community-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -5462,12 +5462,12 @@
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-opentelemetry2</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${camel-quarkus-community.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>
                 <artifactId>camel-quarkus-opentelemetry2-deployment</artifactId>
-                <version>${camel-quarkus.version}</version>
+                <version>${camel-quarkus-community.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel.quarkus</groupId>

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -2224,7 +2224,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-opentelemetry2</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>4.14.0.redhat-00007</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>4.14.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -2756,7 +2756,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-telemetry</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>4.14.0.redhat-00007</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>4.14.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -5344,12 +5344,12 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-quarkus-opentelemetry2</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.27.0.rhbac-SNAPSHOT</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.27.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-quarkus-opentelemetry2-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.27.0.rhbac-SNAPSHOT</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.27.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -2214,7 +2214,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-opentelemetry2</artifactId>
-        <version>4.14.0.redhat-00007</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -2746,7 +2746,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-telemetry</artifactId>
-        <version>4.14.0.redhat-00007</version>
+        <version>4.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
@@ -5334,12 +5334,12 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry2</artifactId>
-        <version>3.27.0.rhbac-SNAPSHOT</version>
+        <version>3.27.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>
         <artifactId>camel-quarkus-opentelemetry2-deployment</artifactId>
-        <version>3.27.0.rhbac-SNAPSHOT</version>
+        <version>3.27.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -2214,7 +2214,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-opentelemetry2</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>4.14.0.redhat-00007</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>4.14.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -2746,7 +2746,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-telemetry</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>4.14.0.redhat-00007</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>4.14.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
@@ -5334,12 +5334,12 @@
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-quarkus-opentelemetry2</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.27.0.rhbac-SNAPSHOT</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.27.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>camel-quarkus-opentelemetry2-deployment</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>3.27.0.rhbac-SNAPSHOT</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>3.27.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.apache.camel.quarkus</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/product/integration-tests-mixed-native/group-02/pom.xml
+++ b/product/integration-tests-mixed-native/group-02/pom.xml
@@ -65,6 +65,7 @@
         <module>../../../integration-tests/oaipmh</module>
         <module>../../../integration-tests/ognl</module>
         <module>../../../integration-tests/openstack</module>
+        <module>../../../integration-tests/opentelemetry2</module>
         <module>../../../integration-tests/optaplanner</module>
         <module>../../../integration-tests/pdf</module>
     </modules>

--- a/product/integration-tests-product/group-04/pom.xml
+++ b/product/integration-tests-product/group-04/pom.xml
@@ -68,6 +68,5 @@
         <module>../../../integration-tests/minio</module>
         <module>../../../integration-tests/mllp</module>
         <module>../../../integration-tests/mybatis</module>
-        <module>../../../integration-tests/netty</module>
     </modules>
 </project>

--- a/product/integration-tests-product/group-05/pom.xml
+++ b/product/integration-tests-product/group-05/pom.xml
@@ -33,11 +33,11 @@
     <name>Camel Quarkus :: Integration Tests :: Product :: Group 05</name>
 
     <modules>
+        <module>../../../integration-tests/netty</module>
         <module>../../../integration-tests/observability-services</module>
         <module>../../../integration-tests/olingo4</module>
         <module>../../../integration-tests/openapi-java</module>
         <module>../../../integration-tests/opentelemetry</module>
-        <module>../../../integration-tests/opentelemetry2</module>
         <module>../../../integration-tests/paho</module>
         <module>../../../integration-tests/paho-mqtt5</module>
         <module>../../../integration-tests/platform-http</module>

--- a/product/src/main/generated/productized-camel-quarkus-artifacts.txt
+++ b/product/src/main/generated/productized-camel-quarkus-artifacts.txt
@@ -295,7 +295,6 @@ camel-quarkus-integration-test-olingo4
 camel-quarkus-integration-test-openapi-java
 camel-quarkus-integration-test-opensearch
 camel-quarkus-integration-test-opentelemetry
-camel-quarkus-integration-test-opentelemetry2
 camel-quarkus-integration-test-paho
 camel-quarkus-integration-test-paho-mqtt5
 camel-quarkus-integration-test-platform-http
@@ -524,9 +523,6 @@ camel-quarkus-opensearch-parent
 camel-quarkus-opentelemetry
 camel-quarkus-opentelemetry-deployment
 camel-quarkus-opentelemetry-parent
-camel-quarkus-opentelemetry2
-camel-quarkus-opentelemetry2-deployment
-camel-quarkus-opentelemetry2-parent
 camel-quarkus-paho
 camel-quarkus-paho-deployment
 camel-quarkus-paho-mqtt5

--- a/product/src/main/generated/required-productized-camel-artifacts.txt
+++ b/product/src/main/generated/required-productized-camel-artifacts.txt
@@ -103,7 +103,6 @@ camel-olingo4
 camel-openapi-java
 camel-opensearch
 camel-opentelemetry
-camel-opentelemetry2
 camel-paho
 camel-paho-mqtt5
 camel-platform-http-vertx

--- a/product/src/main/generated/transitive-dependencies-non-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-non-productized.txt
@@ -415,6 +415,7 @@ org.apache.camel:camel-nitrite
 org.apache.camel:camel-oaipmh
 org.apache.camel:camel-ognl
 org.apache.camel:camel-openstack
+org.apache.camel:camel-opentelemetry2
 org.apache.camel:camel-optaplanner
 org.apache.camel:camel-pdf
 org.apache.camel:camel-pg-replication-slot
@@ -452,6 +453,7 @@ org.apache.camel:camel-stub
 org.apache.camel:camel-swift
 org.apache.camel:camel-syslog
 org.apache.camel:camel-tarfile
+org.apache.camel:camel-telemetry
 org.apache.camel:camel-telemetry-dev
 org.apache.camel:camel-test-junit5
 org.apache.camel:camel-threadpoolfactory-vertx
@@ -720,6 +722,8 @@ org.apache.camel.quarkus:camel-quarkus-ognl
 org.apache.camel.quarkus:camel-quarkus-ognl-deployment
 org.apache.camel.quarkus:camel-quarkus-openstack
 org.apache.camel.quarkus:camel-quarkus-openstack-deployment
+org.apache.camel.quarkus:camel-quarkus-opentelemetry2
+org.apache.camel.quarkus:camel-quarkus-opentelemetry2-deployment
 org.apache.camel.quarkus:camel-quarkus-optaplanner
 org.apache.camel.quarkus:camel-quarkus-optaplanner-deployment
 org.apache.camel.quarkus:camel-quarkus-pdf

--- a/product/src/main/generated/transitive-dependencies-productized.txt
+++ b/product/src/main/generated/transitive-dependencies-productized.txt
@@ -782,7 +782,6 @@ org.apache.camel:camel-olingo4-api
 org.apache.camel:camel-openapi-java
 org.apache.camel:camel-opensearch
 org.apache.camel:camel-opentelemetry
-org.apache.camel:camel-opentelemetry2
 org.apache.camel:camel-paho
 org.apache.camel:camel-paho-mqtt5
 org.apache.camel:camel-platform-http
@@ -809,7 +808,6 @@ org.apache.camel:camel-sql
 org.apache.camel:camel-ssh
 org.apache.camel:camel-support
 org.apache.camel:camel-telegram
-org.apache.camel:camel-telemetry
 org.apache.camel:camel-timer
 org.apache.camel:camel-tooling-model
 org.apache.camel:camel-tooling-util
@@ -1046,8 +1044,6 @@ org.apache.camel.quarkus:camel-quarkus-opensearch
 org.apache.camel.quarkus:camel-quarkus-opensearch-deployment
 org.apache.camel.quarkus:camel-quarkus-opentelemetry
 org.apache.camel.quarkus:camel-quarkus-opentelemetry-deployment
-org.apache.camel.quarkus:camel-quarkus-opentelemetry2
-org.apache.camel.quarkus:camel-quarkus-opentelemetry2-deployment
 org.apache.camel.quarkus:camel-quarkus-paho
 org.apache.camel.quarkus:camel-quarkus-paho-deployment
 org.apache.camel.quarkus:camel-quarkus-paho-mqtt5


### PR DESCRIPTION
https://issues.redhat.com/browse/CEQ-11848