### PR TITLE
Use mirror.gcr.io for testcontainers alpine image

### DIFF
--- a/Jenkinsfile.redhat
+++ b/Jenkinsfile.redhat
@@ -27,6 +27,7 @@ pipeline {
     environment {
         MAVEN_OPTS = '-Xmx3g'
         TESTCONTAINERS_RYUK_DISABLED = 'true'
+        TESTCONTAINERS_TINYIMAGE_CONTAINER_IMAGE = 'mirror.gcr.io/alpine:3.17'
     }
 
     options {


### PR DESCRIPTION
Should help save some time for CI waiting for `docker.io` rate limits to expire