### PR TITLE
skip IBM MQ tests on aarch64 due to missing arm64 container image

### DIFF
--- a/integration-tests/jms-ibmmq-client/pom.xml
+++ b/integration-tests/jms-ibmmq-client/pom.xml
@@ -95,6 +95,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel.quarkus</groupId>
+            <artifactId>camel-quarkus-integration-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQPoolingTest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQPoolingTest.java
@@ -26,6 +26,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQDestinations;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQTestResource;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
+import org.apache.camel.quarkus.test.DisabledOnArm;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -37,6 +38,7 @@ import static org.hamcrest.Matchers.is;
 @QuarkusTestResource(IBMMQTestResource.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestProfile(JmsPoolingEnabled.class)
+@DisabledOnArm
 public class IBMMQPoolingTest extends AbstractJmsMessagingTest {
     private IBMMQDestinations destinations;
 

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQTest.java
@@ -24,6 +24,7 @@ import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQDestinations;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQTestResource;
 import org.apache.camel.quarkus.messaging.jms.AbstractJmsMessagingTest;
+import org.apache.camel.quarkus.test.DisabledOnArm;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.is;
 @QuarkusTest
 @QuarkusTestResource(IBMMQTestResource.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnArm
 public class IBMMQTest extends AbstractJmsMessagingTest {
     private IBMMQDestinations destinations;
 

--- a/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQXATest.java
+++ b/integration-tests/jms-ibmmq-client/src/test/java/org/apache/camel/quarkus/component/jms/ibmmq/it/IBMMQXATest.java
@@ -23,6 +23,7 @@ import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQDestinations;
 import org.apache.camel.quarkus.component.jms.ibmmq.support.IBMMQTestResource;
+import org.apache.camel.quarkus.test.DisabledOnArm;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import static org.hamcrest.core.Is.is;
 @QuarkusTestResource(IBMMQTestResource.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestProfile(JmsXAEnabled.class)
+@DisabledOnArm
 public class IBMMQXATest {
     private IBMMQDestinations destinations;
 


### PR DESCRIPTION
backport from main