### PR TITLE
feat: deprecate support for opentelemetry, splunk and olingo4

### DIFF
--- a/product/src/main/generated/camel-quarkus-product.json
+++ b/product/src/main/generated/camel-quarkus-product.json
@@ -881,7 +881,8 @@
       "artifact-id": "camel-quarkus-olingo4",
       "metadata": {
         "redhat-camel-support": [
-          "supported"
+          "supported",
+          "deprecated"
         ]
       }
     },
@@ -918,6 +919,7 @@
       "artifact-id": "camel-quarkus-opentelemetry",
       "metadata": {
         "redhat-camel-support": [
+          "supported",
           "deprecated"
         ]
       }
@@ -1128,7 +1130,8 @@
       "artifact-id": "camel-quarkus-splunk",
       "metadata": {
         "redhat-camel-support": [
-          "supported"
+          "supported",
+          "deprecated"
         ]
       }
     },

--- a/product/src/main/resources/camel-quarkus-product-source.json
+++ b/product/src/main/resources/camel-quarkus-product-source.json
@@ -519,9 +519,13 @@
             "comment": "supported since CEQ 3.20.0"
         },
         "camel-quarkus-olingo4": {
-            "jvm": "supported",
-            "native": "supported",
-            "comment": "supported since CEQ 3.20.0"
+            "jvm": "deprecated",
+            "native": "deprecated",
+            "redhat-camel-support":[
+                "supported",
+                "deprecated"
+            ],
+            "comment": "supported since CEQ 3.20.0, deprecated since CEQ 3.33.0"
         },
         "camel-quarkus-openai": {
             "jvm": "supported",
@@ -541,6 +545,10 @@
         "camel-quarkus-opentelemetry": {
             "jvm": "deprecated",
             "native": "deprecated",
+            "redhat-camel-support":[
+                "supported",
+                "deprecated"
+            ],
             "comment": "tp since CEQ 2.13.1, supported since CEQ 3.8.0, deprecated since CEQ 3.33.0"
         },
         "camel-quarkus-opentelemetry2": {
@@ -654,9 +662,13 @@
             "comment": "supported/tp since CEQ 2.2.0, supported since CEQ 2.7.1"
         },
         "camel-quarkus-splunk": {
-            "jvm": "supported",
-            "native": "supported",
-            "comment": "supported since CEQ 3.2.0"
+            "jvm": "deprecated",
+            "native": "deprecated",
+            "redhat-camel-support":[
+                "supported",
+                "deprecated"
+            ],
+            "comment": "supported since CEQ 3.2.0, deprecated since CEQ 3.33.0"
         },
         "camel-quarkus-splunk-hec": {
             "jvm": "supported",


### PR DESCRIPTION
Depends on: https://github.com/l2x6/cq-maven-plugin/pull/856
Linked to: https://github.com/redhat-developer/code.quarkus.redhat.com/pull/230

Should replace:
* https://github.com/jboss-fuse/camel-quarkus/pull/596
* https://github.com/jboss-fuse/camel-quarkus/pull/594
