### PR TITLE
Revert "cq maven plugin version updated to 4.23.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <maven-utils.version>0.1.0</maven-utils.version>
 
         <!-- Maven plugin versions (keep sorted alphabetically) -->
-        <cq-plugin.version>4.23.0</cq-plugin.version>
+        <cq-plugin.version>4.22.1</cq-plugin.version>
         <cyclonedx-maven-plugin-version>2.9.1</cyclonedx-maven-plugin-version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>


### PR DESCRIPTION
Reverting commit cc426d7acd6 (Maven plugin update to 4.23.0). This change was inadvertently pushed directly to the midstream branch; I will be resubmitting this via a formal Pull Request shortly.