### PR TITLE
Downgrade to Jolokia 2.5.0, Upgrade to Quarkus CXF 3.33.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <jira-rest-client.version>${jira-rest-client-api-version}</jira-rest-client.version>
         <jnr-constants.version>0.9.11</jnr-constants.version><!-- Mess in web3j transitive deps -->
         <jnr-ffi.version>2.2.13</jnr-ffi.version><!-- Mess in web3j transitive deps -->
-        <jolokia.version>2.5.1</jolokia.version>
+        <jolokia.version>2.5.0</jolokia.version>
         <jsch.version>2.28.0</jsch.version><!-- @sync io.quarkiverse.jsch:quarkus-jsch:${quarkiverse-jsch.version} dep:com.github.mwiede:jsch -->
         <json-path.version>${json-path-version}</json-path.version>
         <jedis-client.version>${jedis-client-version}</jedis-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <quarkiverse-amazonservices.version>3.15.1</quarkiverse-amazonservices.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/amazonservices/quarkus-amazon-services-parent/ -->
         <quarkiverse-artemis.version>3.13.1.redhat-00002</quarkiverse-artemis.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/artemis/quarkus-artemis-parent/ -->
         <quarkiverse-batik.version>1.1.0</quarkiverse-batik.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/batik/quarkus-batik-parent/ -->
-        <quarkiverse-cxf.version>3.33.2</quarkiverse-cxf.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
+        <quarkiverse-cxf.version>3.33.3</quarkiverse-cxf.version><!-- This should be in sync with quarkus-platform https://repo1.maven.org/maven2/io/quarkiverse/cxf/quarkus-cxf-parent/ -->
         <quarkiverse-cxf-community.version>3.33.2</quarkiverse-cxf-community.version>
         <quarkiverse-freemarker.version>1.3.0</quarkiverse-freemarker.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/freemarker/quarkus-freemarker-parent/ -->
         <quarkiverse-fory.version>0.5.0</quarkiverse-fory.version><!-- https://repo1.maven.org/maven2/io/quarkiverse/fury/quarkus-fury-parent/ -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -8493,535 +8493,535 @@
         <version>7.6.0.202603022253-r</version><!-- io.quarkiverse.jgit:quarkus-jgit-bom:3.6.2 -->
       </dependency>
       <dependency>
-        <groupId>commons-collections</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>commons-collections</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>commons-collections</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>commons-collections</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.velocity</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>velocity-engine-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>2.4.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.velocity</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>velocity-engine-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>2.4.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-jaxb-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-jaxb-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-management-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-management-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-test-util</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-test-util</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>7.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>7.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.5.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.5.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>metrics-json</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>metrics-json</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>org.bouncycastle</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.bouncycastle</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.11.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.11.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-plugins-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-plugins-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.29 -->

--- a/poms/bom/src/main/generated/flattened-full-pom.xml
+++ b/poms/bom/src/main/generated/flattened-full-pom.xml
@@ -8081,7 +8081,7 @@
       <dependency>
         <groupId>org.jolokia</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jolokia-agent-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.5.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.5.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.json</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -8475,147 +8475,147 @@
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-axiom-api-stub</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-jaxb-plugins</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-jaxb-plugins-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-management</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-management-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-bc-stub</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-saaj-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-services-sts-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-test-util</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-woodstox-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>io.quarkiverse.cxf</groupId>
         <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId>
-        <version>3.33.2</version>
+        <version>3.33.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
@@ -8710,7 +8710,7 @@
       <dependency>
         <groupId>org.apache.neethi</groupId>
         <artifactId>neethi</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-pom.xml
@@ -7984,7 +7984,7 @@
       <dependency>
         <groupId>org.jolokia</groupId>
         <artifactId>jolokia-agent-jvm</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -7984,7 +7984,7 @@
       <dependency>
         <groupId>org.jolokia</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
         <artifactId>jolokia-agent-jvm</artifactId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
-        <version>2.5.1</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
+        <version>2.5.0</version><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->
       </dependency>
       <dependency>
         <groupId>org.json</groupId><!-- org.apache.camel.quarkus:camel-quarkus-bom:${project.version} -->

--- a/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
+++ b/poms/bom/src/main/generated/flattened-reduced-verbose-pom.xml
@@ -8361,535 +8361,535 @@
         <version>7.6.0.202603022253-r</version><!-- io.quarkiverse.jgit:quarkus-jgit-bom:3.6.2 -->
       </dependency>
       <dependency>
-        <groupId>commons-collections</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>commons-collections</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>commons-collections</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>commons-collections</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-transports-http</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-mex</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-wsdl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.ow2.asm</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>asm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.services.sts</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-services-sts-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-boolean</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-dv</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-javadoc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-pl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-ts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjcplugins</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-wsdlextension</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf.xjc-utils</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-xjc-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.santuario</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.velocity</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>velocity-engine-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>2.4.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.velocity</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>velocity-engine-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>2.4.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-axiom-api-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-integration-tracing-opentelemetry-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-jaxb-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-jaxb-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-logging-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-features-metrics-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-management-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-management-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-security-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-bc-stub</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-rt-ws-rm-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-saaj</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-saaj-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-santuario-xmlsec-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-services-sts</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-services-sts-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-test-util</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-test-util</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-woodstox</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-woodstox-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.33.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>io.quarkiverse.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>quarkus-cxf-xjc-plugins-deployment</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.33.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>7.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.fasterxml.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>woodstox-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>7.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.sun.xml.fastinfoset</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>FastInfoset</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>2.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.xml</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jsr173</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.xml.bind</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jsr173_api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>com.sun.xml.messaging.saaj</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>saaj-impl</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.0.4</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.5.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.client5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpclient5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.5.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpcore5</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.httpcomponents.core5</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>httpcore5-h2</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>5.3.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-bindings</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>metrics-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>metrics-json</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>io.dropwizard.metrics</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>metrics-json</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>org.bouncycastle</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.bouncycastle</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>*</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-dom</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-policy-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.wss4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wss4j-ws-security-stax</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.2.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.neethi</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>neethi</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.codehaus.woodstox</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>stax2-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.2.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.11.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.ehcache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>ehcache</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.11.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <classifier>jakarta</classifier><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.glassfish.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-xjc</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.6</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jasypt</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jasypt</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.9.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-plugins</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.slf4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jcl-over-slf4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jaxb-plugins-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.jaxb</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jaxb-plugins-runtime</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.12</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.jvnet.mimepull</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>mimepull</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.10.0</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>jakarta.xml.soap</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jakarta.xml.soap-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>3.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>com.sun.activation</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>jakarta.activation</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>jakarta.xml.ws</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>jakarta.xml.ws-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.0.2</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>javax.cache</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cache-api</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.1.1</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>wsdl4j</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>wsdl4j</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>1.6.3</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-integration-tracing-opentelemetry</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-bindings-soap</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-bindings-xml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-frontend-simple</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-management</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-rs-json-basic</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-rs-security-jose</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-security-saml</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-addr</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-ws-policy</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-rt-security</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-common</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-java2ws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
         <exclusions>
           <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cxf-rt-databinding-aegis</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
           <exclusion>
-            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+            <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+            <artifactId>cxf-rt-javascript</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-validator</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-core</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-databinding-jaxb</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
-        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
-        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.2 -->
+        <groupId>org.apache.cxf</groupId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <artifactId>cxf-tools-wsdlto-frontend-jaxws</artifactId><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
+        <version>4.1.5</version><!-- io.quarkiverse.cxf:quarkus-cxf-bom:3.33.3 -->
       </dependency>
       <dependency>
         <groupId>org.apache.groovy</groupId><!-- org.apache.groovy:groovy-bom:4.0.29 -->

--- a/product/settings.xml
+++ b/product/settings.xml
@@ -3,6 +3,15 @@
     xmlns="http://maven.apache.org/SETTINGS/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <mirrors>
+        <mirror>
+            <id>central-mirror</id>
+            <name>Maven Central Mirror</name>
+            <url>https://nexus.corp.redhat.com/repository/maven-central/</url>
+            <mirrorOf>central</mirrorOf>
+        </mirror>
+    </mirrors>
     <profiles>
         <profile>
             <id>prod</id>


### PR DESCRIPTION
Jolokia https://redhat.atlassian.net/browse/CEQ-13230
Quarkus CXF 3.33.3 brings Neethi 3.2.2 https://ws.apache.org/neethi/security.html