### PR TITLE
Remove the last rest of quarkus-junit5*

### DIFF
--- a/extensions/infinispan-cluster-service/deployment/pom.xml
+++ b/extensions/infinispan-cluster-service/deployment/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5-internal</artifactId>
+            <artifactId>quarkus-junit-internal</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests-jvm/cics/pom.xml
+++ b/integration-tests-jvm/cics/pom.xml
@@ -47,7 +47,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests-jvm/sap/pom.xml
+++ b/integration-tests-jvm/sap/pom.xml
@@ -61,7 +61,7 @@
         <!-- test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
those were renamed to quarkus-junit* in Quarkus 3.31.0 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#junit-6-gear-white_check_mark
