### PR TITLE
[cics] Add full license cics image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <arangodb.container.image>mirror.gcr.io/arangodb:3.12.0</arangodb.container.image>
         <azurite.container.image>mcr.microsoft.com/azure-storage/azurite:3.35.0</azurite.container.image>
         <calculator-ws.container.image>quay.io/l2x6/calculator-ws:1.2</calculator-ws.container.image>
-        <cics.container.image>images.paas.redhat.com/fuseqe/ibm-cicstg-container-linux-x86-trial:10.1</cics.container.image>
+        <cics.container.image>quay.io/rh_integration/ibm-cicstg-container-linux-x86:10.1</cics.container.image>
         <cassandra.container.image>mirror.gcr.io/cassandra:5.0.2</cassandra.container.image>
         <consul.container.image>mirror.gcr.io/hashicorp/consul:1.21</consul.container.image>
         <couchbase.container.image>mirror.gcr.io/couchbase/server:7.6.2</couchbase.container.image>


### PR DESCRIPTION
Trial cics image has 3 months expiration, after that time someone had to download and upload new one. This one is permanent, downloaded from ibm software page. Should solve the all the time licence expiration.

@ppalaga is it ok to use quay.io/rh-integration repo? And should I cheery pick also to upstream?